### PR TITLE
Add filtering example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The [`recipes`](recipes/) directory holds different sample use cases for working
 operator and auto-instrumentation along with setup guides for each recipe. Currently there are:
 
 * [Trace sampling configuration](recipes/trace-sampling)
-* Trace filtering (coming soon)
+* [Trace filtering](recipes/trace-filtering)
 * Trace enhancements (coming soon)
 * [Cloud Trace integration](recipes/cloud-trace)
 

--- a/recipes/trace-filtering/README.md
+++ b/recipes/trace-filtering/README.md
@@ -1,0 +1,47 @@
+# Filtering out spans
+
+This recipe demonstrates how to configure the OpenTelemetry Collector
+to filter out spans.
+
+This recipe is based on applying a Collector config that includes the `filter` processor.
+It provides an `OpenTelemetryCollector` object that, when created, instructs the Operator to
+create a new instance of the Collector with that config. If overwriting an existing `OpenTelemetryCollector`
+object (i.e., you already have a running Collector through the Operator such as the one from the
+[main README](../../README.md#starting-the-collector)), the Operator will update that existing
+Collector with the new config.
+
+
+## Prerequisites
+
+* A running Kubernetes cluster
+* The OpenTelemetry Operator installed in your cluster
+* A Collector deployed with the Operator (recommended)
+* [One of the sample apps](../../sample-apps) from this repo installed in the cluster
+
+Note that the `OpenTelemetryCollector` object needs to be in the same namespace as your sample
+app, or the Collector endpoint needs to be updated to point to the correct service address.
+
+## Running
+
+### Deploying the Recipe
+
+Apply the `OpenTelemetryCollector` object from this recipe:
+
+```
+kubectl apply -f collector-config.yaml
+```
+
+(This will overwrite any existing collector config, or create a new one if none exists.)
+
+### Checking the filtered Spans
+
+To stream logs from the otel-collector, run:
+```
+kubectl logs deployment/otel-collector -f
+```
+
+You should see only client spans, where `service.name` is `<sample>-app`. You should not see any spans from the server, where `service.name` is `<sample>-service`, as those are filtered out.
+
+## Learn More
+
+The filter processor can filter on more than just service name! For a complete description of its capabilities, see the upstream [README](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor#filter-processor).

--- a/recipes/trace-filtering/collector-config.yaml
+++ b/recipes/trace-filtering/collector-config.yaml
@@ -1,0 +1,51 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  image: otel/opentelemetry-collector-contrib:latest
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+
+    processors:
+      filter:
+        spans:
+          include:
+            match_type: regexp
+            # Keep the NodeJS, Python, and Java example client spans
+            services:
+              - .*-app.*
+          exclude:
+            match_type: regexp
+            # Filter out the NodeJS, Python, and Java example server spans
+            services:
+              - .*-service
+
+    exporters:
+      logging:
+        logLevel: debug
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [filter]
+          exporters: [logging]


### PR DESCRIPTION
It filters by the service name, which has been consistent across the applications.  I've opted to filter out all server spans.  That way, we keep the root span in the tree if we are viewing them in a UI.

I tested this with all three sample apps.