### PR TITLE
give instructions on next steps after sample app installation

### DIFF
--- a/sample-apps/java/README.md
+++ b/sample-apps/java/README.md
@@ -8,9 +8,12 @@ running as a CronJob.
 * OpenTelemetry Operator installed in your cluster
 * Artifact Registry set up in your GCP project (see the 
 [main README.md](../../README.md#sample-applications))
-* An `Instrumentation` object already created in the current namespace
-  (such as [the sample `instrumentation.yaml`](#auto-instrumenting-applications)
-  from the main [README](../../README.md))
+* An `OpenTelemetryCollector` object already created in the current namespace,
+  such as [the sample `collector-config.yaml`](../../README.md#starting-the-Collector)
+  from the main [README](../../README.md)
+* An `Instrumentation` object already created in the current namespace,
+  such as [the sample `instrumentation.yaml`](../../README.md#auto-instrumenting-applications)
+  from the main [README](../../README.md)
 
 ## Running
 
@@ -34,3 +37,12 @@ running as a CronJob.
    kubectl patch cronjob.batch/javashowcase-app -p '{"spec":{"jobTemplate":{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-java": "true"}}}}}}}'
    ```
    These commands will use the `Instrumentation` created as part of the Prerequisites.
+
+## View your Spans
+
+To stream logs from the otel-collector, which will include spans from this sample application, run:
+```
+kubectl logs deployment/otel-collector -f
+```
+
+Alternatively, follow the [cloud-trace recipe](../../recipes/cloud-trace/) to view your spans in Google Cloud Trace.

--- a/sample-apps/nodejs/README.md
+++ b/sample-apps/nodejs/README.md
@@ -8,9 +8,12 @@ server listens for requests which the client makes on a timed loop.
 * OpenTelemetry Operator installed in your cluster
 * Artifact Registry set up in your GCP project (see the 
 [main README.md](../../README.md#sample-applications))
-* An `Instrumentation` object already created in the current namespace
-  (such as [the sample `instrumentation.yaml`](#auto-instrumenting-applications)
-  from the main [README](../../README.md))
+* An `OpenTelemetryCollector` object already created in the current namespace,
+  such as [the sample `collector-config.yaml`](../../README.md#starting-the-Collector)
+  from the main [README](../../README.md)
+* An `Instrumentation` object already created in the current namespace,
+  such as [the sample `instrumentation.yaml`](../../README.md#auto-instrumenting-applications)
+  from the main [README](../../README.md)
 
 ## Running
 
@@ -40,3 +43,12 @@ server listens for requests which the client makes on a timed loop.
    kubectl patch deployment.apps/nodeshowcase-service -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-nodejs": "true"}}}}}'
    ```
    These commands will use the `Instrumentation` created as part of the Prerequisites.
+
+## View your Spans
+
+To stream logs from the otel-collector, which will include spans from this sample application, run:
+```
+kubectl logs deployment/otel-collector -f
+```
+
+Alternatively, follow the [cloud-trace recipe](../../recipes/cloud-trace/) to view your spans in Google Cloud Trace.

--- a/sample-apps/python/README.md
+++ b/sample-apps/python/README.md
@@ -8,9 +8,12 @@ server listens for requests which the client makes on a timed loop.
 * OpenTelemetry Operator installed in your cluster
 * Artifact Registry set up in your GCP project (see the 
 [main README.md](../../README.md#sample-applications))
-* An `Instrumentation` object already created in the current namespace
-  (such as [the sample `instrumentation.yaml`](#auto-instrumenting-applications)
-  from the main [README](../../README.md))
+* An `OpenTelemetryCollector` object already created in the current namespace,
+  such as [the sample `collector-config.yaml`](../../README.md#starting-the-Collector)
+  from the main [README](../../README.md)
+* An `Instrumentation` object already created in the current namespace,
+  such as [the sample `instrumentation.yaml`](../../README.md#auto-instrumenting-applications)
+  from the main [README](../../README.md)
 
 ## Running
 
@@ -40,3 +43,12 @@ server listens for requests which the client makes on a timed loop.
    kubectl patch deployment.apps/pythonshowcase-service -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-python": "true"}}}}}'
    ```
    These commands will use the `Instrumentation` created as part of the Prerequisites.
+
+## View your Spans
+
+To stream logs from the otel-collector, which will include spans from this sample application, run:
+```
+kubectl logs deployment/otel-collector -f
+```
+
+Alternatively, follow the [cloud-trace recipe](../../recipes/cloud-trace/) to view your spans in Google Cloud Trace.


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operator-sample/issues/11.  Now, after I install an application, I know how to see the spans from that app.

Also, fixes the link to #auto-instrumenting-applications.