### PR TITLE
All logging processors use logLevel: debug so users can see span details

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -27,6 +27,7 @@ spec:
 
     exporters:
       logging:
+        logLevel: debug
 
     service:
       pipelines:

--- a/recipes/cloud-trace/collector-config.yaml
+++ b/recipes/cloud-trace/collector-config.yaml
@@ -29,6 +29,7 @@ spec:
     exporters:
       googlecloud:
       logging:
+        logLevel: debug
 
     service:
       pipelines:


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/opentelemetry-operator-sample/issues/8

I verified that the logging exporter outputs detailed trace information in both samples.