### PR TITLE
Add basic gke cloudbuild install test

### DIFF
--- a/cloudbuild-gke.yaml
+++ b/cloudbuild-gke.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: "install"
+    name: "gcr.io/cloud-builders/gcloud"
+    env:
+      - "KUBECONFIG=/kube/config"
+      - "PROJECT_ID=$PROJECT_ID"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+
+        gcloud container clusters get-credentials "${_CLUSTER}" \
+        --project "$${PROJECT}" \
+        --zone "${_ZONE}"
+
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+        while ! kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml; do echo "Retrying"; sleep 5; done

--- a/cloudbuild-gke.yaml
+++ b/cloudbuild-gke.yaml
@@ -13,19 +13,30 @@
 # limitations under the License.
 
 steps:
-  - id: "install"
-    name: "gcr.io/cloud-builders/gcloud"
+  - id: "cert-manager"
+    name: "gcr.io/cloud-builders/kubectl"
     env:
-      - "KUBECONFIG=/kube/config"
-      - "PROJECT_ID=$PROJECT_ID"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - |
+      - "CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER}"
+      - "CLOUDSDK_COMPUTE_ZONE=${_ZONE}"
+    args: ['apply', '-f', 'https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml']
 
-        gcloud container clusters get-credentials "${_CLUSTER}" \
-        --project "$${PROJECT}" \
-        --zone "${_ZONE}"
+  - id: "install"
+    name: "gcr.io/cloud-builders/kubectl"
+    env:
+      - "CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER}"
+      - "CLOUDSDK_COMPUTE_ZONE=${_ZONE}"
+    args: ['apply', '-f', 'https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml']
 
-        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
-        while ! kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml; do echo "Retrying"; sleep 5; done
+  - id: "cleanup-cert-manager"
+    name: "gcr.io/cloud-builders/kubectl"
+    env:
+      - "CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER}"
+      - "CLOUDSDK_COMPUTE_ZONE=${_ZONE}"
+    args: ['delete', '-f', 'https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml']
+
+  - id: "cleanup-install"
+    name: "gcr.io/cloud-builders/kubectl"
+    env:
+      - "CLOUDSDK_CONTAINER_CLUSTER=${_CLUSTER}"
+      - "CLOUDSDK_COMPUTE_ZONE=${_ZONE}"
+    args: ['delete', '-f', 'https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml']

--- a/sample-apps/nodejs-java/k8s/app.yaml
+++ b/sample-apps/nodejs-java/k8s/app.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: nodeshowcase-app
-          image: %REGISTRY_LOCATION%-docker.pkg.dev/%GCLOUD_PROJECT%/%CONTAINER_REGISTRY%/nodejs-sample:latest
+          image: "%REGISTRY_LOCATION%-docker.pkg.dev/%GCLOUD_PROJECT%/%CONTAINER_REGISTRY%/nodejs-sample:latest"
           command: ['node', 'app.js']
           env:
           - name: "SERVICE_NAME"

--- a/sample-apps/nodejs-java/k8s/service.yaml
+++ b/sample-apps/nodejs-java/k8s/service.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: javashowcase-service
-          image: %REGISTRY_LOCATION%-docker.pkg.dev/%GCLOUD_PROJECT%/%CONTAINER_REGISTRY%/java-sample-service:latest
+          image: "%REGISTRY_LOCATION%-docker.pkg.dev/%GCLOUD_PROJECT%/%CONTAINER_REGISTRY%/java-sample-service:latest"
           ports:
             - containerPort: 8080
           resources:


### PR DESCRIPTION
This adds a basic test to make sure the upstream install commands work on a GKE standard cluster. The goal is just to see that the manifests successfully apply.