### PR TITLE
fixed case for key loglevel on all configs

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -27,7 +27,7 @@ spec:
 
     exporters:
       logging:
-        logLevel: debug
+        loglevel: debug
 
     service:
       pipelines:

--- a/recipes/cloud-trace/collector-config.yaml
+++ b/recipes/cloud-trace/collector-config.yaml
@@ -29,7 +29,7 @@ spec:
     exporters:
       googlecloud:
       logging:
-        logLevel: debug
+        loglevel: debug
 
     service:
       pipelines:

--- a/recipes/resource-detection/collector-config.yaml
+++ b/recipes/resource-detection/collector-config.yaml
@@ -33,7 +33,7 @@ spec:
 
     exporters:
       logging:
-        logLevel: debug
+        loglevel: debug
 
     service:
       pipelines:

--- a/recipes/trace-enhancements/collector-config-resource-detection.yaml
+++ b/recipes/trace-enhancements/collector-config-resource-detection.yaml
@@ -41,7 +41,7 @@ spec:
 
     exporters:
       logging:
-        logLevel: debug
+        loglevel: debug
 
     service:
       pipelines:

--- a/recipes/trace-enhancements/collector-config.yaml
+++ b/recipes/trace-enhancements/collector-config.yaml
@@ -34,7 +34,7 @@ spec:
 
     exporters:
       logging:
-        logLevel: debug
+        loglevel: debug
 
     service:
       pipelines:

--- a/recipes/trace-filtering/collector-config.yaml
+++ b/recipes/trace-filtering/collector-config.yaml
@@ -41,7 +41,7 @@ spec:
 
     exporters:
       logging:
-        logLevel: debug
+        loglevel: debug
 
     service:
       pipelines:


### PR DESCRIPTION
solves the following error:

error decoding 'exporters': error reading configuration for "logging": 1 error(s) decoding: unknown fields logLevel