### PR TITLE
Add a jaeger remote sampling recipe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ operator and auto-instrumentation along with setup guides for each recipe. Curre
 * [Trace enhancements](recipes/trace-enhancements)
 * [Cloud Trace integration](recipes/cloud-trace)
 * [Resource detection](recipes/resource-detection)
+* [Daemonset and Deployment](recipes/daemonset-and-deployment)
+* [eBPF HTTP Observability with Beyla](recipes/beyla)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The [`recipes`](recipes/) directory holds different sample use cases for working
 operator and auto-instrumentation along with setup guides for each recipe. Currently there are:
 
 * [Trace sampling configuration](recipes/trace-sampling)
+* [Trace remote sampling config](recipes/trace-remote-sampling)
 * [Trace filtering](recipes/trace-filtering)
 * [Trace enhancements](recipes/trace-enhancements)
 * [Cloud Trace integration](recipes/cloud-trace)

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -9,3 +9,5 @@ operator and auto-instrumentation. See below to get started:
 * [Trace enhancements](trace-enhancements)
 * [Cloud trace integration](cloud-trace)
 * [Resource detection](resource-detection)
+* [Daemonset and Deployment](daemonset-and-deployment)
+* [eBPF HTTP Observability with Beyla](beyla)

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -4,6 +4,7 @@ This directory holds different "recipe" configurations for the
 operator and auto-instrumentation. See below to get started:
 
 * [Trace sampling config](trace-sampling)
+* [Trace remote sampling config](trace-remote-sampling)
 * [Trace filtering](trace-filtering)
 * [Trace enhancements](trace-enhancements)
 * [Cloud trace integration](cloud-trace)

--- a/recipes/trace-remote-sampling/README.md
+++ b/recipes/trace-remote-sampling/README.md
@@ -17,7 +17,7 @@ This recipe provides three main pieces of configuration:
 
 ## Running
 
-Apply the `ConfigMap` object from [`sampling-config.yaml`](sampling-config.yaml)
+Apply the `ConfigMap` object from [`remote-sampling-config.yaml`](remote-sampling-config.yaml)
 
 ```
 kubectl apply -f remote-sampling-config.yaml
@@ -32,7 +32,7 @@ Apply the `OpenTelemetryCollector` object from [`collector-config.yaml`](collect
 kubectl apply -f collector-config.yaml
 ```
 
-Next, create the `Instrumentation` object from [`instrumetnation.yaml`](instrumentation.yaml) that will use the remote sampling service:
+Next, create the `Instrumentation` object from [`instrumentation.yaml`](instrumentation.yaml) that will use the remote sampling service:
 
 ```
 kubectl apply -f instrumentation.yaml

--- a/recipes/trace-remote-sampling/README.md
+++ b/recipes/trace-remote-sampling/README.md
@@ -1,0 +1,129 @@
+# Trace Remote Sampling Configuration Recipe
+
+This recipe shows how to use the Jaeger Remote Sampling
+protocol to provide fine-grained control of trace sampling.
+
+
+This recipe provides three main pieces of configuration:
+
+- A ConfigMap that provides fine-grained trace sampling controls for the entire cluster.
+- An OpenTelemetryCollector deployment that will serve the control protocol to instrumentation.
+- An Instrumentation configuration that will leverage the OpenTelemetryCollector deployment to look up trace sampling information.
+
+## Prerequisites
+
+* OpenTelemetry Operator installed in your cluster
+* Running un-instrumented application (such as one of the [sample apps](../../sample-apps)).
+
+## Running
+
+Apply the `ConfigMap` object from [`sampling-config.yaml`](sampling-config.yaml)
+
+```
+kubectl apply -f remote-sampling-config.yaml
+```
+
+This creates the configuration for trace sampling. At any point, we can modify the `remote-sampling-config.yaml` file and reperform this step to adjust sampling on the cluster in the future (see [Tuning](#tuning))
+
+
+Apply the `OpenTelemetryCollector` object from [`collector-config.yaml`](collector-config.yaml)
+
+```
+kubectl apply -f collector-config.yaml
+```
+
+Next, create the `Instrumentation` object from [`instrumetnation.yaml`](instrumentation.yaml) that will use the remote sampling service:
+
+```
+kubectl apply -f instrumentation.yaml
+```
+
+This creates a new object named `instrumentation/trace-remote-sampling` in the current namespace.
+
+Annotate your application pods to use these settings by editing the `instrumentation.opentelemetry.io`
+annotation using one of the following commands:
+
+> Note that if the app is a standalone Pod you can
+>`kubectl annotate` directly on the Pod, but if it is owned by a Deployment or other replica controller
+> you must patch the metadata of the Pod template.
+
+* **NodeJS:**
+
+  Pod:
+  ```
+  kubectl annotate pod/<APP-NAME> instrumentation.opentelemetry.io/inject-nodejs="trace-remote-sampling"
+  ```
+  Deployment:
+  ```
+  kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-nodejs": "trace-remote-sampling"}}}}}'
+  ```
+
+* **Java:**
+
+  Pod:
+  ```
+  kubectl annotate pod/<APP-NAME> instrumentation.opentelemetry.io/inject-java="trace-remote-sampling"
+  ```
+  Deployment:
+  ```
+  kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-java": "trace-remote-sampling"}}}}}'
+  ```
+
+* **Python:**
+
+  Pod:
+  ```
+  kubectl annotate pod/<APP-NAME> instrumentation.opentelemetry.io/inject-python="trace-remote-sampling"
+  ```
+  Deployment:
+  ```
+  kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-python": "trace-remote-sampling"}}}}}'
+  ```
+
+* **DotNET:**
+
+  Pod:
+  ```
+  kubectl annotate pod/<APP-NAME> instrumentation.opentelemetry.io/inject-python="trace-remote-sampling"
+  ```
+  Deployment:
+  ```
+  kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-dotnet": "trace-remote-sampling"}}}}}'
+  ```
+
+# Tuning
+
+To tune sampling in the cluster, simply update the `remote-sampling-config.yaml` and reapply:
+
+```
+kubectl apply -f remote-sampling-config.yaml
+```
+
+The OpenTelemetryCollector deployment should pick up changes within a few seconds of the ConfigMap rollout, and clients will further pull in those changes within a few minutes.
+
+This can help, e.g. when needing to increase the sampling rate of a service for better observability "on the fly" and turn it back down after collecting enough data.
+
+The format of the remote sampling configuration is [documented here](https://www.jaegertracing.io/docs/1.28/sampling/#collector-sampling-configuration).
+
+An example configuration which disables tracing prometheus metrics and health checks would look as follows:
+
+```json
+{
+  "default_strategy": {
+    "type": "probabilistic",
+    "param": 0.5,
+    "operation_strategies": [
+      {
+        "operation": "GET /health",
+        "type": "probabilistic",
+        "param": 0.0
+      },
+      {
+        "operation": "GET /metrics",
+        "type": "probabilistic",
+        "param": 0.0
+      }
+    ]
+  }
+}
+```

--- a/recipes/trace-remote-sampling/README.md
+++ b/recipes/trace-remote-sampling/README.md
@@ -40,23 +40,15 @@ kubectl apply -f instrumentation.yaml
 
 This creates a new object named `instrumentation/trace-remote-sampling` in the current namespace.
 
+> Note that `jaeger_remote` sampler configuration is
+> only available in Java and Go as of 2023-10-18.
+
 Annotate your application pods to use these settings by editing the `instrumentation.opentelemetry.io`
 annotation using one of the following commands:
 
 > Note that if the app is a standalone Pod you can
 >`kubectl annotate` directly on the Pod, but if it is owned by a Deployment or other replica controller
 > you must patch the metadata of the Pod template.
-
-* **NodeJS:**
-
-  Pod:
-  ```
-  kubectl annotate pod/<APP-NAME> instrumentation.opentelemetry.io/inject-nodejs="trace-remote-sampling"
-  ```
-  Deployment:
-  ```
-  kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-nodejs": "trace-remote-sampling"}}}}}'
-  ```
 
 * **Java:**
 
@@ -67,28 +59,6 @@ annotation using one of the following commands:
   Deployment:
   ```
   kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-java": "trace-remote-sampling"}}}}}'
-  ```
-
-* **Python:**
-
-  Pod:
-  ```
-  kubectl annotate pod/<APP-NAME> instrumentation.opentelemetry.io/inject-python="trace-remote-sampling"
-  ```
-  Deployment:
-  ```
-  kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-python": "trace-remote-sampling"}}}}}'
-  ```
-
-* **DotNET:**
-
-  Pod:
-  ```
-  kubectl annotate pod/<APP-NAME> instrumentation.opentelemetry.io/inject-python="trace-remote-sampling"
-  ```
-  Deployment:
-  ```
-  kubectl patch deployment.apps/<APP-NAME> -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-dotnet": "trace-remote-sampling"}}}}}'
   ```
 
 # Tuning

--- a/recipes/trace-remote-sampling/README.md
+++ b/recipes/trace-remote-sampling/README.md
@@ -69,7 +69,7 @@ To tune sampling in the cluster, simply update the `remote-sampling-config.yaml`
 kubectl apply -f remote-sampling-config.yaml
 ```
 
-The OpenTelemetryCollector deployment should pick up changes within a few seconds of the ConfigMap rollout, and clients will further pull in those changes within a few minutes.
+The OpenTelemetryCollector deployment should pick up changes within a few minutes of the ConfigMap rollout, and clients will further pull in those changes within a few minutes.
 
 This can help, e.g. when needing to increase the sampling rate of a service for better observability "on the fly" and turn it back down after collecting enough data.
 

--- a/recipes/trace-remote-sampling/collector-config.yaml
+++ b/recipes/trace-remote-sampling/collector-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/trace-remote-sampling/collector-config.yaml
+++ b/recipes/trace-remote-sampling/collector-config.yaml
@@ -1,0 +1,60 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  image: otel/opentelemetry-collector-contrib:latest
+  # We need to specify ports so remote sampler is exposed.
+  ports:
+    - port: 4317
+      name: otlp
+    - port: 4318
+      name: otlp-grpc
+    - port: 5778
+      name: jaeger
+    - port: 14250
+      name: jaeger-grpc
+  # Connect the config-map w/ our jaeger sampler config so we can update it quickly.
+  volumes:
+  - name: sampling-config-volume
+    configMap:
+      name: remote-sampling-config
+  volumeMounts:
+  - name: sampling-config-volume
+    mountPath: /etc/otel/sampling
+    readOnly: true
+  # Ensure the jaeger remote sampler config is enabled as an extension.
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    exporters:
+      debug:
+    extensions:
+      jaegerremotesampling:
+        source:
+          reload_interval: 1s
+          file: /etc/otel/sampling/sampling.json
+    service:
+      extensions: [jaegerremotesampling]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: []
+          exporters: [debug]

--- a/recipes/trace-remote-sampling/collector-config.yaml
+++ b/recipes/trace-remote-sampling/collector-config.yaml
@@ -49,7 +49,7 @@ spec:
     extensions:
       jaegerremotesampling:
         source:
-          reload_interval: 1s
+          reload_interval: 60s
           file: /etc/otel/sampling/sampling.json
     service:
       extensions: [jaegerremotesampling]

--- a/recipes/trace-remote-sampling/instrumentation.yaml
+++ b/recipes/trace-remote-sampling/instrumentation.yaml
@@ -1,0 +1,43 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: trace-remote-sampling
+spec:
+
+# Default exporting OTLP to the gRPC interface of a collector.
+  exporter:
+    endpoint: http://otel-collector:4317
+
+# Use w3c `traceparent` and `baggage` for propgation of distributed values.
+  propagators:
+    - tracecontext
+    - baggage
+
+# Use the Jaeger remote sampling config from the gateway
+#
+# pollingInterval determines how often clients will refresh sampling configuration.
+# initialSamplingRate determines sampling in the event a client cannot connect to the
+#                     the sampling service.
+  sampler:
+    type: jaeger_remote
+    argument: "endpoint=http://otel-collector:14250,pollingIntervalMs=5000,initialSamplingRate=0.25"
+
+# Note: Python currently supports HTTP not GRPC endpoint
+  python:
+    env:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://otel-collector:4318

--- a/recipes/trace-remote-sampling/remote-sampling-config.yaml
+++ b/recipes/trace-remote-sampling/remote-sampling-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: remote-sampling-config
+data:
+  sampling.json: |
+     {
+       "default_strategy": {
+         "type":"probabilistic",
+         "param": 0.5
+       }
+     }

--- a/recipes/trace-remote-sampling/remote-sampling-config.yaml
+++ b/recipes/trace-remote-sampling/remote-sampling-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
I wasn't sure how much detail to get into with configuring Jaeger itself, let me know if the README should walk into how to turn on/off services.


kudos to @aabmass for the original example, modified here to fit opentelemetry-operator