### PR TITLE
Update all sample apps to delegate to NEXT_SERVER env variable.

### DIFF
--- a/sample-apps/go/server/main.go
+++ b/sample-apps/go/server/main.go
@@ -16,12 +16,35 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
 )
 
+func remoteHello(nextServer string) string {
+	resp, err := http.Get(nextServer)
+	if err != nil {
+		log.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return string(body)
+}
+
 func hello(w http.ResponseWriter, _ *http.Request) {
-	fmt.Fprintf(w, "hello\n")
+	url, exists := os.LookupEnv("NEXT_SERVER")
+	if !exists {
+		fmt.Fprintf(w, "hello\n")
+	} else {
+		fmt.Fprintf(w, "%s\n", remoteHello(url))
+	}
 }
 
 func main() {

--- a/sample-apps/nodejs/server.js
+++ b/sample-apps/nodejs/server.js
@@ -16,9 +16,23 @@ var http = require("http");
 
 console.log("serving on port 8080...")
 
+var serviceURL = process.env.NEXT_SERVER
+
 var listener = function (req, res) {
-  res.writeHead(200);
-  res.end(JSON.stringify({data: "Hello world"}));
+
+  if (serviceURL) {
+    http.get(serviceURL, resp => {
+      let data = ''
+      resp.on('data', d => { data += d });
+      resp.on('end', () => { 
+        res.writeHead(200);
+        res.end(data);
+      });
+    });
+  } else {
+    res.writeHead(200);
+    res.end(JSON.stringify({data: "Hello world"}));
+  }
 };
 var server = http.createServer(listener);
 

--- a/sample-apps/python/requirements.txt
+++ b/sample-apps/python/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.2
 MarkupSafe==2.1.3
 packaging==23.2
 Werkzeug==2.3.7
+requests==2.28.1

--- a/sample-apps/python/server.py
+++ b/sample-apps/python/server.py
@@ -15,6 +15,7 @@
 import os
 from flask import Flask
 from flask.json import jsonify
+import requests
 
 app = Flask(__name__)
 
@@ -22,4 +23,12 @@ print(os.environ)
 
 @app.route("/")
 def hello_world():
-    return jsonify({"data": "Hello world"})
+    if 'NEXT_SERVER' in os.environ.keys():
+        try:
+            json = requests.get(os.environ['NEXT_SERVER'], timeout=10).json()
+            return json
+        except requests.RequestException as e:
+            return jsonify({"error": e})
+    else:
+        return jsonify({"data": "Hello world"})
+


### PR DESCRIPTION
- Fix an issue in Python example where `requests` was not required, so `app.py` was broken.
- Add new `NEXT_SERVER` config to all example apps so that users can set up a "chain" or example applications easily.

Note: The new functionality is not yet documented.