### PR TITLE
Fix beyla example, and pin versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ listed above.
 
 ### Installing the OpenTelemetry Operator
 
-Install the latest release of the Operator with:
+Install the the Operator with:
 
 ```
-kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.89.0/opentelemetry-operator.yaml
 ```
 
 ### Starting the Collector

--- a/recipes/beyla/README.md
+++ b/recipes/beyla/README.md
@@ -17,7 +17,6 @@ object (i.e., you already have a running Collector through the Operator such as 
 [main README](../../README.md#starting-the-collector)), the Operator will update that existing
 Collector with the new config.
 
-
 ## Prerequisites
 
 [!WARNING]  

--- a/recipes/beyla/beyla-daemonset.yaml
+++ b/recipes/beyla/beyla-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
               memory: 100Mi
             limits:
               memory: 500Mi
-          image: grafana/beyla:1.0.1
+          image: grafana/beyla:0.4.1
           ports:
           - name: metrics
             containerPort: 8080

--- a/recipes/beyla/beyla-daemonset.yaml
+++ b/recipes/beyla/beyla-daemonset.yaml
@@ -37,10 +37,10 @@ spec:
           resources:
             requests:
               cpu: 10m
-              memory: 60Mi
-            limits:
               memory: 100Mi
-          image: grafana/beyla:latest
+            limits:
+              memory: 500Mi
+          image: grafana/beyla:1.0.1
           ports:
           - name: metrics
             containerPort: 8080
@@ -52,9 +52,9 @@ spec:
               value: "http://otel-collector:4317"
             - name: OTEL_EXPORTER_OTLP_PROTOCOL
               value: "grpc"
-            - name: SYSTEM_WIDE
+            - name: BEYLA_SYSTEM_WIDE
               value: "true"
-            - name: SKIP_GO_SPECIFIC_TRACERS
+            - name: BEYLA_SKIP_GO_SPECIFIC_TRACERS
               value: "true"
-            - name: METRICS_REPORT_TARGET # This is high cardinality, but useful for showing the power of ebpf
-              value: "true"
+            - name: BEYLA_METRICS_INTERVAL
+              value: "30s"

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   config: |
     receivers:
       otlp:

--- a/recipes/cloud-trace/collector-config.yaml
+++ b/recipes/cloud-trace/collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   config: |
     receivers:
       otlp:

--- a/recipes/daemonset-and-deployment/daemonset-collector-config.yaml
+++ b/recipes/daemonset-and-deployment/daemonset-collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   mode: daemonset
   resources:
     requests:

--- a/recipes/daemonset-and-deployment/deployment-collector-config.yaml
+++ b/recipes/daemonset-and-deployment/deployment-collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel-deployment
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   resources:
     requests:
       cpu: 50m

--- a/recipes/resource-detection/collector-config.yaml
+++ b/recipes/resource-detection/collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   config: |
     receivers:
       otlp:

--- a/recipes/trace-enhancements/collector-config-resource-detection.yaml
+++ b/recipes/trace-enhancements/collector-config-resource-detection.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   config: |
     receivers:
       otlp:

--- a/recipes/trace-enhancements/collector-config.yaml
+++ b/recipes/trace-enhancements/collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   config: |
     receivers:
       otlp:

--- a/recipes/trace-filtering/collector-config.yaml
+++ b/recipes/trace-filtering/collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   config: |
     receivers:
       otlp:

--- a/recipes/trace-remote-sampling/collector-config.yaml
+++ b/recipes/trace-remote-sampling/collector-config.yaml
@@ -17,7 +17,7 @@ kind: OpenTelemetryCollector
 metadata:
   name: otel
 spec:
-  image: otel/opentelemetry-collector-contrib:latest
+  image: otel/opentelemetry-collector-contrib:0.90.0
   # We need to specify ports so remote sampler is exposed.
   ports:
     - port: 4317


### PR DESCRIPTION
Beyla renamed some config when it released v1.0.  This fixes that, and also pins image versions so examples don't break in the future.  It does mean we need to periodically bump image versions, but that seems preferable to users trying and failing to use samples.