### PR TITLE
Remove unnecessary beyla config, move to spanmetrics-based golden signals

### DIFF
--- a/recipes/beyla/beyla-daemonset.yaml
+++ b/recipes/beyla/beyla-daemonset.yaml
@@ -27,11 +27,7 @@ spec:
       labels:
         app: beyla
     spec:
-      # TODO: define narrower permisisons requirements
       hostPID: true
-      hostNetwork: true
-      hostIPC: true
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: beyla
           resources:
@@ -41,17 +37,12 @@ spec:
             limits:
               memory: 500Mi
           image: grafana/beyla:0.4.1
-          ports:
-          - name: metrics
-            containerPort: 8080
           securityContext:
             runAsUser: 0
             privileged: true
           env:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://otel-collector:4317"
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: "grpc"
             - name: BEYLA_SYSTEM_WIDE
               value: "true"
             - name: BEYLA_SKIP_GO_SPECIFIC_TRACERS

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -20,30 +20,75 @@ spec:
   image: otel/opentelemetry-collector-contrib:0.90.0
   config: |
     receivers:
+      # receive OTLP spans from Beyla
       otlp:
         protocols:
           grpc:
           http:
-
+    connectors:
+      # convert spans into an http.server.duration metric
+      spanmetrics/httpserver:
+        histogram:
+          unit: 's'
+          explicit:
+            buckets: [10us, 50us, 100us, 200us, 400us, 800us, 1ms, 2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]
+        dimensions:
+          - name: http.method
+            default: GET
+          - name: http.status_code
+          - name: net.host.name
+          - name: http.route
+        exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
+        namespace: http.server
     processors:
+      # filter down to only non-local http server spans
+      filter/httpserveronly:
+        error_mode: ignore
+        traces:
+          span:
+            - attributes["http.method"] == nil
+            - kind.string != "Server"
+            - attributes["net.host.name"] == "127.0.0.1"
+      # detect gke resource attributes
       resourcedetection:
         detectors: [env, gcp]
         timeout: 2s
         override: false
-
+      # Move net.host.name from a metric attribute to a resource attribute so we can use it to get k8s attributes.
+      groupbyattrs:
+        keys:
+          - net.host.name
+      # Assume net.host.name is a pod IP address
+      resource:
+        attributes:
+          - key: k8s.pod.ip
+            from_attribute: net.host.name
+            action: insert
+      k8sattributes:
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+      # Filter out metrics that aren't about pods
+      filter/podonly:
+        metrics:
+          metric:
+            - resource.attributes["k8s.pod.name"] == nil
     exporters:
       googlemanagedprometheus:
+        metric:
+          resource_filters:
+            - regex: 'k8s\..*\.name'
       googlecloud:
       logging:
         loglevel: debug
-
     service:
       pipelines:
-        metrics:
-          receivers: [otlp]
-          processors: [resourcedetection]
-          exporters: [logging, googlemanagedprometheus]
         traces:
           receivers: [otlp]
-          processors: [resourcedetection]
-          exporters: [logging, googlecloud]
+          processors: [filter/httpserveronly]
+          exporters: [spanmetrics/httpserver]
+        metrics/spanmetrics:
+          receivers: [spanmetrics/httpserver]
+          processors: [resourcedetection, groupbyattrs, resource, k8sattributes, filter/podonly]
+          exporters: [logging, googlemanagedprometheus]


### PR DESCRIPTION
the protocol is inferred, some permissions were not required, and we don't use a prometheus exporters.