### PR TITLE
Update beyla to the stable release

### DIFF
--- a/recipes/beyla/beyla-daemonset.yaml
+++ b/recipes/beyla/beyla-daemonset.yaml
@@ -36,12 +36,12 @@ spec:
               memory: 100Mi
             limits:
               memory: 500Mi
-          image: grafana/beyla:0.4.1
+          image: grafana/beyla:1.2.0
           securityContext:
             runAsUser: 0
             privileged: true
           env:
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: "http://otel-collector:4317"
             - name: BEYLA_SYSTEM_WIDE
               value: "true"
@@ -49,3 +49,8 @@ spec:
               value: "true"
             - name: BEYLA_METRICS_INTERVAL
               value: "30s"
+            - name: BEYLA_METRICS_REPORT_CACHE_LEN
+              value: "256"
+            - name: BEYLA_TRACES_REPORT_CACHE_LEN
+              value: "256"
+              

--- a/recipes/beyla/beyla-daemonset.yaml
+++ b/recipes/beyla/beyla-daemonset.yaml
@@ -53,4 +53,3 @@ spec:
               value: "256"
             - name: BEYLA_TRACES_REPORT_CACHE_LEN
               value: "256"
-              

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -50,7 +50,7 @@ spec:
           - name: http.response.status_code
           - name: server.address
           - name: http.route
-          - name: net.sock.peer.addr
+          - name: network.peer.address
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
         namespace: http.servicegraph
     processors:

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -50,7 +50,7 @@ spec:
           - name: http.response.status_code
           - name: server.address
           - name: http.route
-          - name: network.peer.address
+          - name: client.address
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
         namespace: http.servicegraph
     processors:

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -35,7 +35,7 @@ spec:
         dimensions:
           - name: http.request.method
             default: GET
-          - name: http.status_code
+          - name: http.response.status_code
           - name: net.host.name
           - name: http.route
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
@@ -47,7 +47,7 @@ spec:
         dimensions:
           - name: http.request.method
             default: GET
-          - name: http.status_code
+          - name: http.response.status_code
           - name: net.host.name
           - name: http.route
           - name: net.sock.peer.addr
@@ -102,8 +102,8 @@ spec:
               - set(name, "http_requests") where name == "http.server.request.calls"
           - context: datapoint
             statements:
-              - set(attributes["code"], attributes["http.status_code"])
-              - delete_key(attributes, "http.status_code")
+              - set(attributes["code"], attributes["http.response.status_code"])
+              - delete_key(attributes, "http.response.status_code")
               - set(attributes["method"], attributes["http.request.method"])
               - delete_key(attributes, "http.request.method")
               # GMP metrics are expected to be double

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -33,7 +33,7 @@ spec:
           explicit:
             buckets: [10us, 50us, 100us, 200us, 400us, 800us, 1ms, 2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]
         dimensions:
-          - name: http.method
+          - name: http.request.method
             default: GET
           - name: http.status_code
           - name: net.host.name
@@ -45,7 +45,7 @@ spec:
         histogram:
           disable: true
         dimensions:
-          - name: http.method
+          - name: http.request.method
             default: GET
           - name: http.status_code
           - name: net.host.name
@@ -59,7 +59,7 @@ spec:
         error_mode: ignore
         traces:
           span:
-            - attributes["http.method"] == nil
+            - attributes["http.request.method"] == nil
             - kind.string != "Server"
             - attributes["net.host.name"] == "127.0.0.1"
       # detect gke resource attributes
@@ -104,8 +104,8 @@ spec:
             statements:
               - set(attributes["code"], attributes["http.status_code"])
               - delete_key(attributes, "http.status_code")
-              - set(attributes["method"], attributes["http.method"])
-              - delete_key(attributes, "http.method")
+              - set(attributes["method"], attributes["http.request.method"])
+              - delete_key(attributes, "http.request.method")
               # GMP metrics are expected to be double
               - set(value_double, Double(value_int))
       resource/podinstance:

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -26,7 +26,7 @@ spec:
           grpc:
           http:
     connectors:
-      # convert spans into an http.server.duration metric
+      # convert spans into an http.server.request.duration metric
       spanmetrics/httpserver:
         histogram:
           unit: 's'
@@ -39,7 +39,7 @@ spec:
           - name: net.host.name
           - name: http.route
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
-        namespace: http.server
+        namespace: http.server.request
       # convert spans into an http.servicegraph.calls metric
       spanmetrics/httpservicegraph:
         histogram:
@@ -98,8 +98,8 @@ spec:
         metric_statements:
           - context: metric
             statements:
-              - set(name, "http_request_duration") where name == "http.server.duration"
-              - set(name, "http_requests") where name == "http.server.calls"
+              - set(name, "http_request_duration") where name == "http.server.request.duration"
+              - set(name, "http_requests") where name == "http.server.request.calls"
           - context: datapoint
             statements:
               - set(attributes["code"], attributes["http.status_code"])

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -36,7 +36,7 @@ spec:
           - name: http.request.method
             default: GET
           - name: http.response.status_code
-          - name: net.host.name
+          - name: server.address
           - name: http.route
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
         namespace: http.server.request
@@ -48,7 +48,7 @@ spec:
           - name: http.request.method
             default: GET
           - name: http.response.status_code
-          - name: net.host.name
+          - name: server.address
           - name: http.route
           - name: net.sock.peer.addr
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
@@ -61,21 +61,21 @@ spec:
           span:
             - attributes["http.request.method"] == nil
             - kind.string != "Server"
-            - attributes["net.host.name"] == "127.0.0.1"
+            - attributes["server.address"] == "127.0.0.1"
       # detect gke resource attributes
       resourcedetection:
         detectors: [env, gcp]
         timeout: 2s
         override: false
-      # Move net.host.name from a metric attribute to a resource attribute so we can use it to get k8s attributes.
+      # Move server.address from a metric attribute to a resource attribute so we can use it to get k8s attributes.
       groupbyattrs:
         keys:
-          - net.host.name
-      # Assume net.host.name is a pod IP address
+          - server.address
+      # Assume server.address is a pod IP address
       resource:
         attributes:
           - key: k8s.pod.ip
-            from_attribute: net.host.name
+            from_attribute: server.address
             action: insert
       k8sattributes:
         extract:

--- a/recipes/beyla/graphgen/internal/query.go
+++ b/recipes/beyla/graphgen/internal/query.go
@@ -28,7 +28,7 @@ import (
 const (
 	// metrics are based on server side, so the peer is the caller (client) and pod is the
 	// callee (server)
-	clientIpKey  = "net_sock_peer_addr"
+	clientIpKey  = "client_address"
 	serverIpKey  = "k8s_pod_ip"
 	serverPodKey = "k8s_pod_name"
 )
@@ -64,7 +64,7 @@ func QueryPrometheus(ctx context.Context, client api.Client, queryWindow time.Du
 func getQuery(queryWindow time.Duration) string {
 	return fmt.Sprintf(
 		`sum by (
-			k8s_pod_ip, net_sock_peer_addr, k8s_pod_name
+			k8s_pod_ip, client_address, k8s_pod_name
 		) (
 			rate(http_servicegraph_calls_total[%s])
 		)`,

--- a/recipes/beyla/graphgen/internal/query_test.go
+++ b/recipes/beyla/graphgen/internal/query_test.go
@@ -35,7 +35,7 @@ const testJson = `{
         "metric": {
           "k8s_pod_ip": "10.112.0.0",
           "k8s_pod_name": "child1",
-          "net_sock_peer_addr": "10.112.1.100"
+          "client_address": "10.112.1.100"
         },
         "value": [1703024317.243, "0.09666750444003214"]
       },
@@ -43,7 +43,7 @@ const testJson = `{
         "metric": {
           "k8s_pod_ip": "10.112.0.1",
           "k8s_pod_name": "child2",
-          "net_sock_peer_addr": "10.112.1.100"
+          "client_address": "10.112.1.100"
         },
         "value": [1703024317.243, "0.09666750444003214"]
       },
@@ -51,7 +51,7 @@ const testJson = `{
         "metric": {
           "k8s_pod_ip": "10.112.0.2",
           "k8s_pod_name": "leaf",
-          "net_sock_peer_addr": "10.112.0.1"
+          "client_address": "10.112.0.1"
         },
         "value": [1703024317.243, "0.09666750444003214"]
       }

--- a/recipes/beyla/graphgen/main.go
+++ b/recipes/beyla/graphgen/main.go
@@ -37,7 +37,7 @@ var (
 const (
 	// metrics are based on server side, so the peer is the caller (client) and pod is the
 	// callee (server)
-	clientIpKey  = "net_sock_peer_addr"
+	clientIpKey  = "client_address"
 	serverIpKey  = "k8s_pod_ip"
 	serverPodKey = "k8s_pod_name"
 )


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-operator-sample/issues/61
By increasing the exporter cache length.

Also:

* Adapts to the stable HTTP semantic conventions.
* Sets only TRACES endpoint to remove errors from beyla when it attempts to export metrics.