### PR TITLE
Set source and target compatibility for gradle to Java 11

### DIFF
--- a/sample-apps/java/buildSrc/src/main/kotlin/com.google.example.java-common-conventions.gradle.kts
+++ b/sample-apps/java/buildSrc/src/main/kotlin/com.google.example.java-common-conventions.gradle.kts
@@ -28,3 +28,8 @@ tasks.test {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 }
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}


### PR DESCRIPTION
Allows the Java sample to reliably run on machines with Java 11+

Issue reported in #75 