### PR TITLE
Use default runtime seccomp profile and drop unnecessary capabilities

### DIFF
--- a/recipes/beyla/beyla-daemonset.yaml
+++ b/recipes/beyla/beyla-daemonset.yaml
@@ -42,12 +42,16 @@ spec:
               memory: 500Mi
           image: grafana/beyla:1.2.0
           securityContext:
+            seccompProfile:
+              type: RuntimeDefault
             runAsUser: 0
             readOnlyRootFilesystem: true
             capabilities:
               add:
                 - SYS_ADMIN
                 - SYS_PTRACE
+              drop:
+                - ALL
           env:
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
               value: "http://otel-collector:4317"


### PR DESCRIPTION
part of https://github.com/GoogleCloudPlatform/opentelemetry-operator-sample/issues/78

Tested manually