### PR TITLE
Split Beyla golden metrics sample out

### DIFF
--- a/recipes/beyla-golden-signals/README.md
+++ b/recipes/beyla-golden-signals/README.md
@@ -1,11 +1,11 @@
 # eBPF HTTP Golden Signals with Beyla
 
 This recipe demonstrates how to configure the OpenTelemetry Collector (as deployed by the
-Operator) to send [Beyla](https://github.com/grafana/beyla) golden signals (RED metrics) to
-[Google Managed Service for
+Operator) to produce golden signal metrics from [Beyla](https://github.com/grafana/beyla) spans
+and send those metrics to [Google Managed Service for
 Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus).
 
-In this recipe, Beyla is configured to collect HTTP RED metrics from all
+In this recipe, Beyla is configured to collect http traces from all
 workloads in the cluster without any code changes. Beyla has other features,
 such as auto-instrumentation for Go applications, but this sample does not use
 it for that purpose.

--- a/recipes/beyla-golden-signals/README.md
+++ b/recipes/beyla-golden-signals/README.md
@@ -1,0 +1,155 @@
+# eBPF HTTP Golden Signals with Beyla
+
+This recipe demonstrates how to configure the OpenTelemetry Collector (as deployed by the
+Operator) to send [Beyla](https://github.com/grafana/beyla) golden signals (RED metrics) to
+[Google Managed Service for
+Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus).
+
+In this recipe, Beyla is configured to collect HTTP RED metrics from all
+workloads in the cluster without any code changes. Beyla has other features,
+such as auto-instrumentation for Go applications, but this sample does not use
+it for that purpose.
+
+This recipe is based on applying a Collector config that enables the Google Cloud exporter.
+It provides an `OpenTelemetryCollector` object that, when created, instructs the Operator to
+create a new instance of the Collector with that config. If overwriting an existing `OpenTelemetryCollector`
+object (i.e., you already have a running Collector through the Operator such as the one from the
+[main README](../../README.md#starting-the-collector)), the Operator will update that existing
+Collector with the new config.
+
+## Prerequisites
+
+> [!WARNING]  
+> Beyla only works with GKE standard clusters, because GKE Auto restricts the use of privileged pods.
+
+* Cloud Monitoring API enabled in your GCP project
+* The `roles/monitoring.metricWriter`
+  [IAM permissions](https://cloud.google.com/trace/docs/iam#roles) for your cluster's service
+  account (or Workload Identity setup as shown below).
+* A running (non-autopilot) GKE cluster
+* The OpenTelemetry Operator installed in your cluster
+* A Collector deployed with the Operator (recommended) or a ServiceAccount that can be used by the new Collector.
+  * Note: This recipe assumes that you already have a Collector ServiceAccount named `otel-collector`,
+    which is created by the operator when deploying an `OpenTelemetryCollector` object such as the
+    one [in this repo](../../collector-config.yaml).
+* An application already deployed that makes or serves HTTP requests:
+  * Note: Beyla does not currently support HTTPS or gRPC
+  * [One of the sample apps](../../sample-apps) from this repo, without auto-instrumentation enabled.
+
+Note that the `OpenTelemetryCollector` object needs to be in the same namespace as your sample
+app, or the Collector endpoint needs to be updated to point to the correct service address.
+
+## Running
+
+### Deploying the Recipe
+
+Apply the role-based access control (RBAC) configuration:
+
+```
+kubectl apply -f rbac.yaml
+```
+
+This allows the Collector's `k8sattributes` processor to read additional metadata from the
+Kubernetes API to enrich the telemetry. See [`k8sattributes`
+documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.90.0/processor/k8sattributesprocessor/README.md#role-based-access-control)
+for more information. If you are deploying the `OpenTelemetryCollector` object in a namespace
+other than `default`, make sure to update the `namespace` property of the ServiceAccount in
+[`rbac.yaml`](rbac.yaml#L38).
+
+Apply the `OpenTelemetryCollector` object from this recipe:
+
+```
+kubectl apply -f collector-config.yaml
+```
+
+(This will overwrite any existing collector config, or create a new one if none exists.)
+
+Once the Collector restarts, apply the Beyla Daemonset:
+
+```
+kubectl apply -f beyla-daemonset.yaml
+```
+
+This will begin creating metrics for all http traffic on each node, and exporting them to
+Google Managed Service for Prometheus.
+
+### Workload Identity Setup
+
+If you have Workload Identity enabled, you'll see permissions errors after deploying the recipe.
+You need to set up a GCP service account with permission to write traces to Cloud Trace, and allow
+the Collector's Kubernetes service account to act as your GCP service account. You can do this with
+the following commands:
+
+```
+export GCLOUD_PROJECT=<your GCP project ID>
+gcloud iam service-accounts create otel-collector --project=${GCLOUD_PROJECT}
+```
+
+Then give that service account permission to write traces and metrics:
+
+```
+gcloud projects add-iam-policy-binding $GCLOUD_PROJECT \
+    --member "serviceAccount:otel-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role "roles/cloudtrace.agent"
+```
+
+```
+gcloud projects add-iam-policy-binding $GCLOUD_PROJECT \
+    --member "serviceAccount:otel-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role "roles/monitoring.metricWriter"
+```
+
+Then bind the GCP service account to the Kubernetes ServiceAccount that is used by the Collector
+you deployed in the prerequisites (note: set `$COLLECTOR_NAMESPACE` to the namespace you installed
+the Collector in):
+
+```
+export COLLECTOR_NAMESPACE=default
+gcloud iam service-accounts add-iam-policy-binding "otel-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:${GCLOUD_PROJECT}.svc.id.goog[${COLLECTOR_NAMESPACE}/otel-collector]"
+```
+
+**(Optional):** If you don't already have a ServiceAccount for the Collector (such as the one provided
+when deploying a prior OpenTelemetryCollector object), create it with `kubectl create serviceaccount otel-collector`.
+
+Finally, annotate the OpenTelemetryCollector Object to allow the Collector's ServiceAccount to use Workload Identity:
+
+```
+kubectl annotate opentelemetrycollector otel \
+    --namespace $COLLECTOR_NAMESPACE \
+    iam.gke.io/gcp-service-account=otel-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com
+```
+
+## View your Metrics
+
+Navigate to the Metrics explorer and look for the `http_server_duration` and
+`http_client_duration` metrics.
+
+## Troubleshooting
+
+### rpc error: code = PermissionDenied
+
+An error such as the following:
+
+```
+2022/10/21 13:41:11 failed to export to Google Cloud Trace: rpc error: code = PermissionDenied desc = The caller does not have permission
+```
+
+This indicates that your Collector is unable to export spans, likely due to misconfigured IAM. Things to check:
+
+#### GKE (cluster-side) config issues
+
+With some configurations it's possible that the Operator could overwrite an existing ServiceAccount when deploying
+a new Collector. Ensure that the Collector's service account has the `iam.gke.io/gcp-service-account` annotation after
+running the `kubectl apply...` command in [Deploying the Recipe](#deploying-the-recipe). If this is missing, re-run the
+`kubectl annotate` command to add it to the ServiceAccount and restart the Collector Pod by deleting it (`kubectl delete pod/otel-collector-xxx..`).
+
+#### GCP (project-side) config issues
+
+Double check that IAM is properly configured for Cloud Monitoring access. This includes:
+
+* Verify the `otel-collector` service account exists in your GCP project
+* That service account must have `roles/monitoring.metricWriter` permissions
+* The `serviceAccount:${GCLOUD_PROJECT}.svc.id.goog[${COLLECTOR_NAMESPACE}/otel-collector]` member must also be bound
+  to the `roles/iam.workloadIdentityUser` role (this identifies the Kubernetes ServiceAccount as able to use Workload Identity)

--- a/recipes/beyla-golden-signals/beyla-daemonset.yaml
+++ b/recipes/beyla-golden-signals/beyla-daemonset.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/beyla-golden-signals/beyla-daemonset.yaml
+++ b/recipes/beyla-golden-signals/beyla-daemonset.yaml
@@ -1,0 +1,76 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: beyla-agent
+  labels:
+    app: beyla
+spec:
+  selector:
+    matchLabels:
+      app: beyla
+  template:
+    metadata:
+      labels:
+        app: beyla
+      annotations:
+        # allow beyla to write to /sys/fs/bpf by setting the
+        # apparmor policy to unconfined.
+        container.apparmor.security.beta.kubernetes.io/beyla: "unconfined"
+    spec:
+      hostPID: true
+      containers:
+        - name: beyla
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi
+            limits:
+              memory: 500Mi
+          image: grafana/beyla:1.2.0
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault
+            runAsUser: 0
+            readOnlyRootFilesystem: true
+            capabilities:
+              add:
+                - SYS_ADMIN
+                - SYS_PTRACE
+              drop:
+                - ALL
+          env:
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: "http://otel-collector:4317"
+            - name: BEYLA_SYSTEM_WIDE
+              value: "true"
+            - name: BEYLA_SKIP_GO_SPECIFIC_TRACERS
+              value: "true"
+            - name: BEYLA_METRICS_INTERVAL
+              value: "30s"
+            - name: BEYLA_METRICS_REPORT_CACHE_LEN
+              value: "256"
+            - name: BEYLA_TRACES_REPORT_CACHE_LEN
+              value: "256"
+            - name: BEYLA_BPF_FS_BASE_DIR
+              value: "/sys/fs/bpf"
+          volumeMounts:
+          - name: bpffs
+            mountPath: /sys/fs/bpf
+      volumes:
+      - name: bpffs
+        hostPath:
+          path: /sys/fs/bpf

--- a/recipes/beyla-golden-signals/collector-config.yaml
+++ b/recipes/beyla-golden-signals/collector-config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/beyla-golden-signals/collector-config.yaml
+++ b/recipes/beyla-golden-signals/collector-config.yaml
@@ -1,0 +1,123 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  image: otel/opentelemetry-collector-contrib:0.90.0
+  config: |
+    receivers:
+      # receive OTLP spans from Beyla
+      otlp:
+        protocols:
+          grpc:
+          http:
+    connectors:
+      # convert spans into an http.server.request.duration metric
+      spanmetrics/httpserver:
+        histogram:
+          unit: 's'
+          explicit:
+            buckets: [10us, 50us, 100us, 200us, 400us, 800us, 1ms, 2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]
+        dimensions:
+          - name: http.request.method
+            default: GET
+          - name: http.response.status_code
+          - name: server.address
+          - name: http.route
+        exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
+        namespace: http.server.request
+    processors:
+      # filter down to only non-local http server spans
+      filter/httpserveronly:
+        error_mode: ignore
+        traces:
+          span:
+            - attributes["http.request.method"] == nil
+            - kind.string != "Server"
+            - attributes["server.address"] == "127.0.0.1"
+      # detect gke resource attributes
+      resourcedetection:
+        detectors: [env, gcp]
+        timeout: 2s
+        override: false
+      # Move server.address from a metric attribute to a resource attribute so we can use it to get k8s attributes.
+      groupbyattrs:
+        keys:
+          - server.address
+      # Assume server.address is a pod IP address
+      resource:
+        attributes:
+          - key: k8s.pod.ip
+            from_attribute: server.address
+            action: insert
+      k8sattributes:
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.namespace.name
+        pod_association:
+          - sources:
+            - from: resource_attribute
+              name: k8s.pod.ip
+      # Filter out metrics that aren't about pods
+      filter/podonly:
+        metrics:
+          metric:
+            - resource.attributes["k8s.pod.name"] == nil
+      # Transform metrics to match GMP http server conventions:
+      # https://cloud.google.com/stackdriver/docs/managed-prometheus/exporters/server/http
+      transform/prometheusconventions:
+        metric_statements:
+          - context: metric
+            statements:
+              - set(name, "http_request_duration") where name == "http.server.request.duration"
+              - set(name, "http_requests") where name == "http.server.request.calls"
+          - context: datapoint
+            statements:
+              - set(attributes["code"], attributes["http.response.status_code"])
+              - delete_key(attributes, "http.response.status_code")
+              - set(attributes["method"], attributes["http.request.method"])
+              - delete_key(attributes, "http.request.method")
+              # GMP metrics are expected to be double
+              - set(value_double, Double(value_int))
+      resource/podinstance:
+        attributes:
+          - key: pod
+            from_attribute: k8s.pod.name
+            action: upsert
+          - key: service.instance.id
+            from_attribute: k8s.pod.uid
+            action: upsert
+    exporters:
+      googlemanagedprometheus:
+        metric:
+          resource_filters:
+            - regex: 'pod'
+      googlecloud:
+      logging:
+        loglevel: debug
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [filter/httpserveronly]
+          exporters: [spanmetrics/httpserver]
+        metrics/spanmetrics:
+          receivers: [spanmetrics/httpserver]
+          processors: [groupbyattrs, resource, k8sattributes, resource/podinstance, filter/podonly, transform/prometheusconventions, resourcedetection]
+          exporters: [logging, googlemanagedprometheus]

--- a/recipes/beyla-golden-signals/collector-config.yaml
+++ b/recipes/beyla-golden-signals/collector-config.yaml
@@ -41,7 +41,9 @@ spec:
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
         namespace: http.server.request
     processors:
-      # filter down to only non-local http server spans
+      # filter down to only non-local http server spans. If the server address is localhost, we
+      # can't differentiate pods from each other, since we use the server address as the pod IP
+      # in a later step.
       filter/httpserveronly:
         error_mode: ignore
         traces:

--- a/recipes/beyla-golden-signals/rbac.yaml
+++ b/recipes/beyla-golden-signals/rbac.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/beyla-golden-signals/rbac.yaml
+++ b/recipes/beyla-golden-signals/rbac.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector
+rules:
+- apiGroups: [""]
+  resources: ["pods", "namespaces", "nodes"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+subjects:
+- kind: ServiceAccount
+  name: otel-collector
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: otel-collector
+  apiGroup: rbac.authorization.k8s.io

--- a/recipes/beyla/collector-config.yaml
+++ b/recipes/beyla/collector-config.yaml
@@ -40,7 +40,9 @@ spec:
           - name: http.route
         exclude_dimensions: ['status.code', 'span.kind', 'span.name', 'service.name']
         namespace: http.server.request
-      # convert spans into an http.servicegraph.calls metric
+      # filter down to only non-local http server spans. If the server address is localhost, we
+      # can't differentiate pods from each other, since we use the server address as the pod IP
+      # in a later step.
       spanmetrics/httpservicegraph:
         histogram:
           disable: true


### PR DESCRIPTION
I am splitting the Beyla sample, which currently has both golden metrics and service graph metrics into two separate samples. This PR splits out the golden metrics and the service graph will come next.

- Copied files
- Updated readme, removing references to Cloud Trace
- Removed service graph from collector config