### PR TITLE
Use Beyla's k8s service discovery instead of BEYLA_SYSTEM_WIDE

### DIFF
--- a/recipes/beyla-golden-signals/beyla-daemonset.yaml
+++ b/recipes/beyla-golden-signals/beyla-daemonset.yaml
@@ -56,11 +56,11 @@ spec:
               drop:
                 - ALL
           env:
+            - name: BEYLA_CONFIG_PATH
+              value: "/config/beyla-config.yml"
             - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
               value: "http://otel-collector:4317"
             - name: BEYLA_KUBE_METADATA_ENABLE
-              value: "true"
-            - name: BEYLA_SYSTEM_WIDE
               value: "true"
             - name: BEYLA_SKIP_GO_SPECIFIC_TRACERS
               value: "true"
@@ -75,7 +75,24 @@ spec:
           volumeMounts:
           - name: bpffs
             mountPath: /sys/fs/bpf
+          - name: beyla-config
+            mountPath: /config
       volumes:
       - name: bpffs
         hostPath:
           path: /sys/fs/bpf
+      - name: beyla-config
+        configMap:
+          name: beyla-config
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: beyla-config
+data:
+  beyla-config.yml: |
+    discovery:
+      services:
+      # only gather metrics from workloads running as a pod
+      - k8s_pod_name: .+


### PR DESCRIPTION
See https://grafana.com/docs/beyla/latest/configure/options/#discovery-services-section

This prevents tracing non-pod processes running on nodes and filters out a lot of junk streams. Kubelet runs short lived scripts (e.g. health checks) that generate a lot of cardinality which leaks memory.

Along with upgrading beyla to 1.3.3, this gives better performance than the `spanmetrics` connector approach used previously:

![image](https://github.com/GoogleCloudPlatform/opentelemetry-operator-sample/assets/1510004/f952e653-553f-48cc-bf67-ee70bb1d5da0)

- Fixed memory/CPU leak from cardinality growth (was affecting beyla and the collector)
- Beyla agent uses ~half as much memory (possibly improved due to version upgrades)
- CPU usage is on par with span metrics for both collector and beyla