### PR TITLE
Add hostmetrics and kubeletstats samples

### DIFF
--- a/recipes/host-and-kubelet-metrics/README.md
+++ b/recipes/host-and-kubelet-metrics/README.md
@@ -1,0 +1,115 @@
+# Host and kubelet metrics
+
+This recipe demonstrates how to configure the OpenTelemetry Collector
+(as deployed by the Operator) to send host and pod-level resource metrics
+[Google Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus).
+
+This recipe is based on applying a Collector config that enables the Google Managed Prometheus exporter.
+It provides an `OpenTelemetryCollector` object that, when created, instructs the Operator to
+create a new instance of the Collector with that config. If overwriting an existing `OpenTelemetryCollector`
+object (i.e., you already have a running Collector through the Operator such as the one from the
+[main README](../../README.md#starting-the-collector)), the Operator will update that existing
+Collector with the new config.
+
+## Prerequisites
+
+* Cloud Monitoring API enabled in your GCP project
+* The `roles/monitoring.metricWriter`
+  [IAM permissions](https://cloud.google.com/trace/docs/iam#roles) for your cluster's service
+  account (or Workload Identity setup as shown below).
+* A running GKE cluster
+* The OpenTelemetry Operator installed in your cluster
+* A Collector deployed with the Operator (recommended) or a ServiceAccount that can be used by the new Collector.
+  * Note: This recipe assumes that you already have a Collector ServiceAccount named `otel-collector`,
+    which is created by the operator when deploying an `OpenTelemetryCollector` object such as the
+    one [in this repo](../../collector-config.yaml).
+
+## Running
+
+### Deploying the Recipe
+
+Apply the `OpenTelemetryCollector` object from this recipe:
+
+```
+kubectl apply -f collector-config.yaml
+```
+
+(This will overwrite any existing collector config, or create a new one if none exists.)
+
+Once the Collector restarts, you should see traces from your application
+
+### Workload Identity Setup
+
+If you have Workload Identity enabled, you'll see permissions errors after deploying the recipe.
+You need to set up a GCP service account with permission to write traces to Cloud Trace, and allow
+the Collector's Kubernetes service account to act as your GCP service account. You can do this with
+the following commands:
+
+```
+export GCLOUD_PROJECT=<your GCP project ID>
+gcloud iam service-accounts create otel-collector --project=${GCLOUD_PROJECT}
+```
+
+Then give that service account permission to write traces:
+
+```
+gcloud projects add-iam-policy-binding $GCLOUD_PROJECT \
+    --member "serviceAccount:otel-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role "roles/monitoring.metricWriter"
+```
+
+Then bind the GCP service account to the Kubernetes ServiceAccount that is used by the Collector
+you deployed in the prerequisites (note: set `$COLLECTOR_NAMESPACE` to the namespace you installed
+the Collector in):
+
+```
+export COLLECTOR_NAMESPACE=default
+gcloud iam service-accounts add-iam-policy-binding "otel-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com" \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:${GCLOUD_PROJECT}.svc.id.goog[${COLLECTOR_NAMESPACE}/otel-collector]"
+```
+
+**(Optional):** If you don't already have a ServiceAccount for the Collector (such as the one provided
+when deploying a prior OpenTelemetryCollector object), create it with `kubectl create serviceaccount otel-collector`.
+
+Finally, annotate the OpenTelemetryCollector Object to allow the Collector's ServiceAccount to use Workload Identity:
+
+```
+kubectl annotate opentelemetrycollector otel \
+    --namespace $COLLECTOR_NAMESPACE \
+    iam.gke.io/gcp-service-account=otel-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com
+```
+
+## View your Metrics
+
+Navigate to console.cloud.google.com/monitoring/metrics-explorer, and in the
+"Select a metric" dropdown, search for "prometheus/k8s" to see kubelet metrics
+or "prometheus/system" to see available host metrics.
+
+## Troubleshooting
+
+### rpc error: code = PermissionDenied
+
+An error such as the following:
+
+```
+2022/10/21 13:41:11 failed to export to Google Cloud Trace: rpc error: code = PermissionDenied desc = The caller does not have permission
+```
+
+This indicates that your Collector is unable to export spans, likely due to misconfigured IAM. Things to check:
+
+#### GKE (cluster-side) config issues
+
+With some configurations it's possible that the Operator could overwrite an existing ServiceAccount when deploying
+a new Collector. Ensure that the Collector's service account has the `iam.gke.io/gcp-service-account` annotation after
+running the `kubectl apply...` command in [Deploying the Recipe](#deploying-the-recipe). If this is missing, re-run the
+`kubectl annotate` command to add it to the ServiceAccount and restart the Collector Pod by deleting it (`kubectl delete pod/otel-collector-xxx..`).
+
+#### GCP (project-side) config issues
+
+Double check that IAM is properly configured for Cloud Trace access. This includes:
+
+* Verify the `otel-collector` service account exists in your GCP project
+* That service account must have `roles/cloudtrace.agent` permissions
+* The `serviceAccount:${GCLOUD_PROJECT}.svc.id.goog[${COLLECTOR_NAMESPACE}/otel-collector]` member must also be bound
+  to the `roles/iam.workloadIdentityUser` role (this identifies the Kubernetes ServiceAccount as able to use Workload Identity)

--- a/recipes/host-and-kubelet-metrics/collector-config.yaml
+++ b/recipes/host-and-kubelet-metrics/collector-config.yaml
@@ -1,0 +1,115 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  image: otel/opentelemetry-collector-contrib:0.98.0
+  mode: daemonset
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  volumes:
+    - name: hostfs
+      hostPath:
+        path: /
+  volumeMounts:
+    - mountPath: /hostfs
+      name: hostfs
+  config: |
+    receivers:
+      hostmetrics:
+        collection_interval: 10s
+        root_path: /hostfs
+        scrapers:
+          cpu:
+          disk:
+          load:
+          memory:
+          network:
+          paging:
+          processes:
+          filesystem:
+            exclude_mount_points:
+              match_type: regexp
+              mount_points:
+              - /var/lib/kubelet/*
+      kubeletstats:
+        collection_interval: 10s
+        auth_type: "none"
+        endpoint: "http://${env:K8S_NODE_NAME}:10255"
+        insecure_skip_verify: true
+
+    processors:
+      resourcedetection:
+        detectors: [gcp]
+        timeout: 10s
+
+      resource:
+        attributes:
+          - action: insert
+            key: k8s.node.name
+            value: ${K8S_NODE_NAME}
+
+      transform:
+        # "location", "cluster", "namespace", "job", "instance", and "project_id" are reserved, and
+        # metrics containing these labels will be rejected.  Prefix them with exported_ to prevent this.
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["exported_location"], attributes["location"])
+          - delete_key(attributes, "location")
+          - set(attributes["exported_cluster"], attributes["cluster"])
+          - delete_key(attributes, "cluster")
+          - set(attributes["exported_namespace"], attributes["namespace"])
+          - delete_key(attributes, "namespace")
+          - set(attributes["exported_job"], attributes["job"])
+          - delete_key(attributes, "job")
+          - set(attributes["exported_instance"], attributes["instance"])
+          - delete_key(attributes, "instance")
+          - set(attributes["exported_project_id"], attributes["project_id"])
+          - delete_key(attributes, "project_id")
+
+      batch:
+        # batch metrics before sending to reduce API usage
+        send_batch_max_size: 200
+        send_batch_size: 200
+        timeout: 5s
+
+      memory_limiter:
+        # drop metrics if memory usage gets too high
+        check_interval: 1s
+        limit_percentage: 65
+        spike_limit_percentage: 20
+
+    exporters:
+      debug:
+        verbosity: detailed
+      googlemanagedprometheus:
+        metric:
+          extra_metrics_config:
+            enable_target_info: false
+          resource_filters:
+            regex: "k8s.*"
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [hostmetrics, kubeletstats]
+          processors: [batch, memory_limiter, resourcedetection, transform, resource]
+          exporters: [googlemanagedprometheus, debug]


### PR DESCRIPTION
It requires disabling the target_info metric because of https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/834