### PR TITLE
Update GCE Beyla sample to use config file

### DIFF
--- a/recipes/beyla-golden-signals/gce/README.md
+++ b/recipes/beyla-golden-signals/gce/README.md
@@ -32,9 +32,8 @@ From the location of this recipe *(beyla-golden-sigals/gce)*, execute the follow
 #### Install and configure Beyla on the VM:
 
 ```sh
-# Make sure to run this without a dot slash (./) since it needs to source variables.
-# Running using ./ will run the script it in a subshell. 
-. configure-beyla.sh
+# Install beyla on VM and configure Ops Agent
+./install-beyla.sh
 ```
 
 #### Check if Google Cloud Ops Agent is still running (Optional):
@@ -51,7 +50,7 @@ sudo systemctl status "google-cloud-ops-agent*"
 
 ```sh
 # Start beyla in the background
-sudo -E beyla &
+sudo beyla --config=beyla-config.yaml &
 ```
 
 ## Build & run the sample Java server app
@@ -62,7 +61,7 @@ sudo -E beyla &
 > If for whatever reason you need to kill the currently running server app, run the following command `fuser -k 8080/tcp`.
 
 ```sh
-# This will start the built server application in the background, listening on port 8080.
+# This will start the built server application in the background, listening on port 8080
 ./run-sample-app.sh
 ```
 

--- a/recipes/beyla-golden-signals/gce/README.md
+++ b/recipes/beyla-golden-signals/gce/README.md
@@ -50,7 +50,7 @@ sudo systemctl status "google-cloud-ops-agent*"
 
 ```sh
 # Start beyla in the background
-sudo beyla --config=beyla-config.yaml &
+sudo beyla --config=beyla-config.yaml 2>&1 > logs_beyla.txt &
 ```
 
 ## Build & run the sample Java server app

--- a/recipes/beyla-golden-signals/gce/beyla-config.yaml
+++ b/recipes/beyla-golden-signals/gce/beyla-config.yaml
@@ -22,9 +22,9 @@ protocol: grpc
 otel_metrics_export:
   endpoint: http://0.0.0.0:4317
   # default includes all possible instrumentations "*"
-  instrumentations: ["http","grpc"]
+  instrumentations: ["http", "grpc"]
   # default only includes "application"
-  features: ["application","application_process"]
+  features: ["application", "application_process"]
 
 otel_traces_export:
   endpoint: http://0.0.0.0:4317
@@ -39,7 +39,7 @@ discovery:
       name: "my-java-service"
       namespace: beyla-gce-java-apps
     # This configuration is not relevant to this sample
-    # since we are only runninfg a java application
+    # since we are only running a java application
     - exe_path: node
       name: "my-node-service"
       namespace: beyla-gce-node-apps

--- a/recipes/beyla-golden-signals/gce/beyla-config.yaml
+++ b/recipes/beyla-golden-signals/gce/beyla-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Beyla can be configured to listen to applications running on multiple ports.
 # Beyla can also be configured globally using environment variables.
 # Environment variables have priority over the properties in the config file.

--- a/recipes/beyla-golden-signals/gce/beyla-config.yaml
+++ b/recipes/beyla-golden-signals/gce/beyla-config.yaml
@@ -12,22 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Beyla can be configured to listen to applications running on multiple ports.
 # Beyla can also be configured globally using environment variables.
 # Environment variables have priority over the properties in the config file.
-open_port: 8080,8082,8083
+# Beyla can be configured to listen to applications running on multiple ports.
+# This configures Beyla to execute all the processes owning one of the ports in
+# the specified range.
+# Limit the range of ports/specify ports if you want Beyla to execute only specific
+# applications. Having a large range might increase resource consumption by Beyla.
+open_port: 1-65536
 trace_printer: text
 protocol: grpc
 
 otel_metrics_export:
   endpoint: http://0.0.0.0:4317
   # default includes all possible instrumentations "*"
-  instrumentations: ["http", "grpc"]
+  instrumentations: ["*"]
   # default only includes "application"
   features: ["application", "application_process"]
 
 otel_traces_export:
-  endpoint: http://0.0.0.0:4317
+  # Uncomment the below line to enable trace generation by Beyla
+  # endpoint: http://0.0.0.0:4317
 
 # This section describes how you can discover various services
 # running on your system and assign them different names and
@@ -39,7 +44,7 @@ discovery:
       name: "my-java-service"
       namespace: beyla-gce-java-apps
     # This configuration is not relevant to this sample
-    # since we are only running a java application
+    # since we are only running a java application.
     - exe_path: node
       name: "my-node-service"
       namespace: beyla-gce-node-apps

--- a/recipes/beyla-golden-signals/gce/beyla-config.yaml
+++ b/recipes/beyla-golden-signals/gce/beyla-config.yaml
@@ -1,0 +1,31 @@
+# Beyla can be configured to listen to applications running on multiple ports.
+# Beyla can also be configured globally using environment variables.
+# Environment variables have priority over the properties in the config file.
+open_port: 8080,8082,8083
+trace_printer: text
+protocol: grpc
+
+otel_metrics_export:
+  endpoint: http://0.0.0.0:4317
+  # default includes all possible instrumentations "*"
+  instrumentations: ["http","grpc"]
+  # default only includes "application"
+  features: ["application","application_process"]
+
+otel_traces_export:
+  endpoint: http://0.0.0.0:4317
+
+# This section describes how you can discover various services
+# running on your system and assign them different names and
+# namespaces based on the exe_path.
+# This feature is not available when configuring through environment variables.
+discovery:
+  services:
+    - exe_path: java
+      name: "my-java-service"
+      namespace: beyla-gce-java-apps
+    # This configuration is not relevant to this sample
+    # since we are only runninfg a java application
+    - exe_path: node
+      name: "my-node-service"
+      namespace: beyla-gce-node-apps

--- a/recipes/beyla-golden-signals/gce/beyla-config.yaml
+++ b/recipes/beyla-golden-signals/gce/beyla-config.yaml
@@ -25,10 +25,6 @@ protocol: grpc
 
 otel_metrics_export:
   endpoint: http://0.0.0.0:4317
-  # default includes all possible instrumentations "*"
-  instrumentations: ["*"]
-  # default only includes "application"
-  features: ["application", "application_process"]
 
 otel_traces_export:
   # Uncomment the below line to enable trace generation by Beyla

--- a/recipes/beyla-golden-signals/gce/install-beyla.sh
+++ b/recipes/beyla-golden-signals/gce/install-beyla.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This script installs and configures beyla on to the current GCE VM instance, installing necessary dependencies.
+# This script installs beyla on to the current GCE VM instance while installing necessary dependencies.
 # The script also configures the installed google-cloud-ops-agent so that it can collect metrics emitted by Beyla.
 
 # Update dependencies
@@ -33,19 +33,6 @@ tar -xzf beyla.tar.gz -C beyla-installation/
 # Move beyla executable to /usr/local/bin
 # /usr/local/bin is the path on a default GCE instance running Debian
 sudo cp beyla-installation/beyla /usr/local/bin
-
-# Configuring Beyla Environment variables when running in direct mode
-echo  "Configuring Beyla..."
-# Beyla configuration options
-export BEYLA_OPEN_PORT=8080
-export BEYLA_TRACE_PRINTER=text
-export BEYLA_SERVICE_NAMESPACE="otel-beyla-gce-sample-service-ns"
-
-# OpenTelemetry export settings
-export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://0.0.0.0:4317"
-export OTEL_SERVICE_NAME="otel-beyla-gce-sample-service"
-echo "Beyla Configured..."
 
 # Apply the custom configuration to installed Google Cloud Ops Agent
 echo "Configuring the Google Cloud Ops Agent..."

--- a/recipes/beyla-golden-signals/gce/run-sample-app.sh
+++ b/recipes/beyla-golden-signals/gce/run-sample-app.sh
@@ -25,4 +25,4 @@ pushd $SAMPLE_APP_JAVA_DIR
 popd
 
 # Run the server application
-java -jar $SAMPLE_APP_JAVA_DIR/service/build/libs/$SERVICE_JAR_FILE &
+java -jar $SAMPLE_APP_JAVA_DIR/service/build/libs/$SERVICE_JAR_FILE 2>&1 > logs_service.txt &


### PR DESCRIPTION
### Description
Updates the sample to use a config file instead of environment variables. Config file can be used to specify service discovery section, which allows the user to group multiple services running on the same VM instance in a single namespace and also provide names to services based on their `exe_path`.

*Note: Environment variables can be used in combination with the config-file, but have been removed in this PR to avoid confusion.*

### Testing
 - Ran the updated scripts with the updated instructions to generate the expected results.