### PR TITLE
Add recipe for OTLP k8s ingest with auto-instrumentation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "recipes/self-managed-otlp-ingest/uninstrumented-app"]
+	path = recipes/self-managed-otlp-ingest/uninstrumented-app
+	url = https://github.com/GoogleCloudPlatform/opentelemetry-operations-java.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "recipes/self-managed-otlp-ingest/uninstrumented-app"]
-	path = recipes/self-managed-otlp-ingest/uninstrumented-app
-	url = https://github.com/GoogleCloudPlatform/opentelemetry-operations-java.git

--- a/recipes/self-managed-otlp-ingest/README.md
+++ b/recipes/self-managed-otlp-ingest/README.md
@@ -4,10 +4,11 @@ This recipe shows how to use self-managed OTLP ingest to export telemetry from a
 
 The example demonstrates a scenario where a user has an application deployed on a GKE cluster and now needs to instrument it and export the generated telemetry to Google Cloud.
 
-## Setting up the scenario
+## Setting up the cluster with an application
 
 > [!TIP]
 > This section outlines the steps to create a cluster & deploy a sample application. Feel free to skip this section and move to [Instrumenting deployed applications](#instrumenting-deployed-applications) if you already have a sample app and cluster setup.
+> Alternatively, you can run a convenience script that executes the steps in this section to give you a cluster with a running application. You can execute this script from the root of this recipe: `./setup-application.sh`. 
 
 ### Creating a GKE cluster
 
@@ -141,9 +142,7 @@ The instrumentation used in the sample is currently configured to generate only 
 
 You can delete the cluster and the artifact registry created using this sample to avoid unnecessary charges:
 ```shell
-# Delete the artifact registry
+# Delete the artifact registry & the created cluster
 gcloud artifacts repositories delete ${CONTAINER_REGISTRY} --location=${REGISTRY_LOCATION}
-
-# Delete the cluster
 gcloud container clusters delete ${CLUSTER_NAME} --location=${CLUSTER_REGION}
 ```

--- a/recipes/self-managed-otlp-ingest/README.md
+++ b/recipes/self-managed-otlp-ingest/README.md
@@ -1,0 +1,149 @@
+# Using Self Managed OTLP ingest with OpenTelemetry Operator
+
+This recipe shows how to use self-managed OTLP ingest to export telemetry from an auto-instrumented application deployed on a GKE cluster.
+
+The example demonstrates a scenario where a user has an application deployed on a GKE cluster and now needs to instrument it and export the generated telemetry to Google Cloud.
+
+## Setting up the scenario
+
+> [!TIP]
+> This section outlines the steps to create a cluster & deploy a sample application. Feel free to skip this section and move to [Instrumenting deployed applications](#instrumenting-deployed-applications) if you already have a sample app and cluster setup.
+
+### Creating a GKE cluster
+
+Run the following commands to create a GKE autopilot cluster. Alternatively, you can create a cluster using the Google Cloud Platform UI.
+
+```shell
+# Setup required environment variables, modify based on your preference
+
+export PROJECT_ID="<your-project-id>"
+export CLUSTER_NAME="opentelemetry-autoinstrument-cluster"
+export CLUSTER_REGION="us-central1"
+```
+
+The following `gcloud` command will begin the cluster creation process.
+```shell
+gcloud beta container --project "${PROJECT_ID}" clusters create-auto "${CLUSTER_NAME}" --region "${CLUSTER_REGION}" --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${CLUSTER_REGION}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=DISABLED
+```
+
+Connect `kubectl` to the created cluster:
+```shell
+gcloud container clusters get-credentials ${CLUSTER_NAME} --region ${CLUSTER_REGION} --project ${PROJECT_ID}
+```
+
+### Deploy sample application (Java) on your cluster
+
+Deploy an un-instrumented application on your GKE cluster. The application used here is the un-instrumented version of the [Java Instrumentation Quickstart](https://github.com/GoogleCloudPlatform/opentelemetry-operations-java/tree/main/examples/instrumentation-quickstart).
+
+To build the sample app, from the root of this recipe:
+```shell
+pushd uninstrumented-app/quickstart-java/examples/instrumentation-quickstart && \
+DOCKER_BUILDKIT=1  docker build -f uninstrumented.Dockerfile -t java-quickstart . && \
+popd
+```
+
+Next, push the locally built image to Google Artifact Registry:
+```shell
+# Export environment variables for configuring Artifact Registry
+export CONTAINER_REGISTRY=<your-registry-name>
+export REGISTRY_LOCATION=us-central1
+
+# If you do not have an Artifact repository, make one:
+gcloud artifacts repositories create ${CONTAINER_REGISTRY} --repository-format=docker --location=${REGISTRY_LOCATION} --description="Sample applications to auto-instrument using OTel operator"
+# Alternatively, you can use any existing artifact registry
+
+docker tag java-quickstart:latest ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/java-quickstart:latest
+docker push ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/java-quickstart:latest
+```
+
+Finally, deploy the pushed application in your cluster:
+```shell
+# This relies on the environment variables exported in previous steps
+envsubst < k8s/quickstart-app.yaml | kubectl apply -f -
+```
+
+Once your application is deployed, you can interact with it by hitting either `/single` or `/multi` endpoints on port `8080`. For more information about the application, view the [application readme](uninstrumented-app/quickstart-java/examples/instrumentation-quickstart/README.md).\
+*Note: You may need to configure port forwarding to interact with this application over localhost.*
+
+## Instrumenting deployed applications
+
+Now that we have an application deployed on a GKE cluster, we can instrument the application using the OpenTelemetry operator.
+
+### Installing OpenTelemetry Operator
+
+We use the OpenTelemetry Operator to inject auto-instrumentation into the apps running in our cluster.
+Follow [these steps](../../README.md#prerequisites) to ensure that `cert-manager` is installed on your cluster.
+
+```shell
+# Install OpenTelemetry Operator
+kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.116.0/opentelemetry-operator.yaml
+```
+
+### Deploying a self-managed OpenTelemetry Collector on the cluster
+
+A self-managed OpenTelemetry Collector can be easily deployed by using scripts from [OTLP Kubernetes Ingest](https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/tree/main) package:
+
+```shell
+kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
+```
+
+This script creates a properly configured Collector with relevant permissions & recommended settings.
+
+> [!IMPORTANT]
+> The following IAM permissions are required to be configured if you have enabled GKE Workload Identity Federation. This example uses GKE Autopilot, which has Workload Identity Federation enabled by default.
+> It is necessary to configure Workload Identity to let the applications running in this cluster authenticate to Google Cloud APIs.
+
+For clusters with GKE Workload Identity Federation enabled, grant the deployed collector relevant IAM permissions:
+```shell
+# This is the number corresponding to your project ID, you can get this by visiting the Google Cloud Platform home page.
+export PROJECT_NUMBER=<your-project-number>
+
+gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
+    --role=roles/logging.logWriter \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --condition=None
+gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
+    --role=roles/monitoring.metricWriter \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --condition=None
+gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
+    --role=roles/cloudtrace.agent \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --condition=None
+```
+
+At this point, there is an OpenTelemetry Collector running in the cluster and is ready to receive telemetry.
+
+### Injecting language specific auto-instrumentation
+
+Using the OpenTelemetry Operator, we can inject language specific auto-instrumentation in applications deployed in the cluster.\
+This is done by first creating the Instrumentation CRD (Custom Resource Definition) and then using annotations to apply the instrumentation to a specific Kubernetes resource.
+
+```shell
+# Create the Instrumentation CRD
+kubectl apply -f instrumentation.yaml
+```
+
+Next, annotate the deployment in which the created instrumentation needs to be injected:
+
+```shell
+# Annotate the deployment to inject the created instrumentation
+# This will trigger a rolling restart of the deployment
+kubectl patch deployment.apps/quickstart-app -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-java": "sample-java-auto-instrumentation"}}}}}'
+```
+
+## Viewing the result
+
+After injecting the application, the application should start producing telemetry which can be viewed in Google Cloud.\
+The instrumentation used in the sample is currently configured to generate only traces and the traces can be viewed on the GCP UI using the Trace Explorer.
+
+## Cleanup
+
+You can delete the cluster and the artifact registry created using this sample to avoid unnecessary charges:
+```shell
+# Delete the artifact registry
+gcloud artifacts repositories delete ${CONTAINER_REGISTRY} --location=${REGISTRY_LOCATION}
+
+# Delete the cluster
+gcloud container clusters delete ${CLUSTER_NAME} --location=${CLUSTER_REGION}
+```

--- a/recipes/self-managed-otlp-ingest/README.md
+++ b/recipes/self-managed-otlp-ingest/README.md
@@ -1,8 +1,12 @@
 # Using Self Managed OTLP ingest with OpenTelemetry Operator
 
-This recipe shows how to use self-managed OTLP ingest to export telemetry from an auto-instrumented application deployed on a GKE cluster.
-
+This recipe shows how to use self-managed OTLP ingest to export telemetry from an auto-instrumented application deployed on a GKE cluster. \
 The example demonstrates a scenario where a user has an application deployed on a GKE cluster and now needs to instrument it and export the generated telemetry to Google Cloud.
+
+There are three broad steps that give the overview for this recipe:
+1. [Running a GKE cluster with a deployed Java application](#setting-up-the-cluster-with-an-application)
+2. [Deploying a self-managed OpenTelemetry Collector](#deploy-a-self-managed-opentelemetry-collector-on-the-cluster)
+3. [Auto-instrumenting the deployed Java application](#instrumenting-deployed-applications)
 
 ## Setting up the cluster with an application
 
@@ -162,7 +166,14 @@ kubectl patch deployment.apps/quickstart-app -n default -p '{"spec":{"template":
 ## Viewing the result
 
 After injecting the application, the application should start producing telemetry which can be viewed in Google Cloud.\
-The instrumentation used in the sample is currently configured to generate only traces and the traces can be viewed on the GCP UI using the Trace Explorer.
+The instrumentation used in the sample is currently configured to generate traces and the traces and metrics.
+ - The traces can be viewed visiting the [trace explorer page](https://cloud.google.com/trace/docs/finding-traces#about) in your project.
+ - The metrics can be viewed visiting the [metrics explorer page](https://console.cloud.google.com/monitoring/metrics-explorer) in your project.
+
+The metrics are exported using [Google managed service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) and will have `prometheus.googleapis.com` as their metric prefix.
+
+If the expected metrics are not visible, please check the collector logs for any potential errors.
+Troubleshooting information for known error types is available [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/googlemanagedprometheusexporter#troubleshooting).
 
 ## Cleanup
 

--- a/recipes/self-managed-otlp-ingest/README.md
+++ b/recipes/self-managed-otlp-ingest/README.md
@@ -7,7 +7,7 @@ The example demonstrates a scenario where a user has an application deployed on 
 ## Setting up the cluster with an application
 
 > [!TIP]
-> This section outlines the steps to create a cluster & deploy a sample application. Feel free to skip this section and move to [Instrumenting deployed applications](#instrumenting-deployed-applications) if you already have a sample app and cluster setup.
+> This section outlines the steps to create a cluster & deploy a sample application. Feel free to skip this section and move to [Instrumenting deployed applications](#instrumenting-deployed-applications) if you already have a sample app and cluster setup. \
 > Alternatively, you can run a convenience script that executes the steps in this section to give you a cluster with a running application. You can execute this script from the root of this recipe: `./setup-application.sh`. 
 
 ### Creating a GKE cluster
@@ -16,7 +16,6 @@ Run the following commands to create a GKE autopilot cluster. Alternatively, you
 
 ```shell
 # Setup required environment variables, modify based on your preference
-
 export PROJECT_ID="<your-project-id>"
 export CLUSTER_NAME="opentelemetry-autoinstrument-cluster"
 export CLUSTER_REGION="us-central1"
@@ -38,9 +37,12 @@ Deploy an un-instrumented application on your GKE cluster. The application used 
 
 To build the sample app, from the root of this recipe:
 ```shell
-pushd uninstrumented-app/examples/instrumentation-quickstart && \
+# We pull the application from GitHub and build it 
+git clone https://github.com/GoogleCloudPlatform/opentelemetry-operations-java.git
+pushd opentelemetry-operations-java/examples/instrumentation-quickstart && \
 DOCKER_BUILDKIT=1  docker build -f uninstrumented.Dockerfile -t java-quickstart . && \
-popd
+popd && \
+rm -rf opentelemetry-operations-java
 ```
 
 Next, push the locally built image to Google Artifact Registry:

--- a/recipes/self-managed-otlp-ingest/README.md
+++ b/recipes/self-managed-otlp-ingest/README.md
@@ -23,7 +23,7 @@ export CLUSTER_REGION="us-central1"
 
 The following `gcloud` command will begin the cluster creation process.
 ```shell
-gcloud beta container --project "${PROJECT_ID}" clusters create-auto "${CLUSTER_NAME}" --region "${CLUSTER_REGION}" --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${CLUSTER_REGION}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=DISABLED
+gcloud beta container --project "${PROJECT_ID}" clusters create-auto "${CLUSTER_NAME}" --region "${CLUSTER_REGION}"
 ```
 
 Connect `kubectl` to the created cluster:
@@ -51,10 +51,11 @@ Next, push the locally built image to Google Artifact Registry:
 export CONTAINER_REGISTRY=<your-registry-name>
 export REGISTRY_LOCATION=us-central1
 
-# If you do not have an Artifact repository, make one:
-gcloud artifacts repositories create ${CONTAINER_REGISTRY} --repository-format=docker --location=${REGISTRY_LOCATION} --description="Sample applications to auto-instrument using OTel operator"
+# If you do not have an Artifact repository, make one.
 # Alternatively, you can use any existing artifact registry
+gcloud artifacts repositories create ${CONTAINER_REGISTRY} --repository-format=docker --location=${REGISTRY_LOCATION} --description="Sample applications to auto-instrument using OTel operator"
 
+# Tag and push the built application image to Google Artifact Registry
 docker tag java-quickstart:latest ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/java-quickstart:latest
 docker push ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/java-quickstart:latest
 ```
@@ -68,35 +69,16 @@ envsubst < k8s/quickstart-app.yaml | kubectl apply -f -
 Once your application is deployed, you can interact with it by hitting either `/single` or `/multi` endpoints on port `8080`. For more information about the application, view the [application readme](uninstrumented-app/examples/instrumentation-quickstart/README.md).\
 *Note: You may need to configure port forwarding to interact with this application over localhost.*
 
-## Instrumenting deployed applications
+## Deploy a self-managed OpenTelemetry Collector on the cluster
 
-Now that we have an application deployed on a GKE cluster, we can instrument the application using the OpenTelemetry operator.
-
-### Installing OpenTelemetry Operator
-
-We use the OpenTelemetry Operator to inject auto-instrumentation into the apps running in our cluster.
-Follow [these steps](../../README.md#prerequisites) to ensure that `cert-manager` is installed on your cluster.
-
-```shell
-# Install OpenTelemetry Operator
-kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.116.0/opentelemetry-operator.yaml
-```
-
-### Deploying a self-managed OpenTelemetry Collector on the cluster
-
-A self-managed OpenTelemetry Collector can be easily deployed by using scripts from [OTLP Kubernetes Ingest](https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/tree/main) package:
-
-```shell
-kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
-```
-
-This script creates a properly configured Collector with relevant permissions & recommended settings.
+This step deploys an [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) instance in the created cluster. 
+Our application will then be configured to send telemetry to this collector instance and the collector will export the generated telemetry to Google Cloud.
 
 > [!IMPORTANT]
 > The following IAM permissions are required to be configured if you have enabled GKE Workload Identity Federation. This example uses GKE Autopilot, which has Workload Identity Federation enabled by default.
-> It is necessary to configure Workload Identity to let the applications running in this cluster authenticate to Google Cloud APIs.
+> It is necessary to configure Workload Identity to let the applications running in this cluster authenticate to Google Cloud APIs. The collector that will be deployed in this cluster will require these permissions
 
-For clusters with GKE Workload Identity Federation enabled, grant the deployed collector relevant IAM permissions:
+For clusters with GKE Workload Identity Federation enabled, grant the relevant IAM permissions:
 ```shell
 # This is the number corresponding to your project ID, you can get this by visiting the Google Cloud Platform home page.
 export PROJECT_NUMBER=<your-project-number>
@@ -114,8 +96,42 @@ gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
     --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
 ```
+*Note: The permissions are being granted to a service account in a given namespace within the cluster. The collector deployment will be configured to use the same service account and namespace.*
 
-At this point, there is an OpenTelemetry Collector running in the cluster and is ready to receive telemetry.
+A self-managed OpenTelemetry Collector can be easily deployed by using scripts from [OTLP Kubernetes Ingest](https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/tree/main) package:
+
+```shell
+kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
+```
+
+This script creates a properly configured Collector with relevant permissions & recommended settings. \
+At this point, there is an OpenTelemetry Collector instance running in the cluster that is ready to receive & export telemetry.
+
+## Instrumenting deployed applications
+
+Now that we have an application deployed on a GKE cluster & an OpenTelemetry Collector instance configured to receive telemetry, we can instrument the application using the OpenTelemetry operator.
+
+### Installing OpenTelemetry Operator
+
+We use the OpenTelemetry Operator to inject auto-instrumentation into the apps running in our cluster.\
+For GKE Autopilot, install `cert-manager` with the following [Helm](https://helm.sh) commands:
+```shell
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install \
+--create-namespace \
+--namespace cert-manager \
+--set installCRDs=true \
+--set global.leaderElection.namespace=cert-manager \
+--set extraArgs={--issuer-ambient-credentials=true} \
+cert-manager jetstack/cert-manager
+```
+
+Install OpenTelemetry Operator with the following command:
+```shell
+# Install OpenTelemetry Operator
+kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.116.0/opentelemetry-operator.yaml
+```
 
 ### Injecting language specific auto-instrumentation
 
@@ -132,7 +148,10 @@ Next, annotate the deployment in which the created instrumentation needs to be i
 ```shell
 # Annotate the deployment to inject the created instrumentation
 # This will trigger a rolling restart of the deployment
-kubectl patch deployment.apps/quickstart-app -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-java": "sample-java-auto-instrumentation"}}}}}'
+kubectl patch deployment.apps/quickstart-app -n default -p '{"spec":{"template":{"metadata":{"annotations":{"instrumentation.opentelemetry.io/inject-java": "default/sample-java-auto-instrumentation"}}}}}'
+
+# This sample shows both instrumentation and application deployment in the default namespace.
+# However, they could be deployed in separate namespaces as well.
 ```
 
 ## Viewing the result
@@ -144,7 +163,7 @@ The instrumentation used in the sample is currently configured to generate only 
 
 You can delete the cluster and the artifact registry created using this sample to avoid unnecessary charges:
 ```shell
-# Delete the artifact registry & the created cluster
-gcloud artifacts repositories delete ${CONTAINER_REGISTRY} --location=${REGISTRY_LOCATION}
+# Delete the created cluster & the artifact registry
 gcloud container clusters delete ${CLUSTER_NAME} --location=${CLUSTER_REGION}
+gcloud artifacts repositories delete ${CONTAINER_REGISTRY} --location=${REGISTRY_LOCATION}
 ```

--- a/recipes/self-managed-otlp-ingest/README.md
+++ b/recipes/self-managed-otlp-ingest/README.md
@@ -37,7 +37,7 @@ Deploy an un-instrumented application on your GKE cluster. The application used 
 
 To build the sample app, from the root of this recipe:
 ```shell
-pushd uninstrumented-app/quickstart-java/examples/instrumentation-quickstart && \
+pushd uninstrumented-app/examples/instrumentation-quickstart && \
 DOCKER_BUILDKIT=1  docker build -f uninstrumented.Dockerfile -t java-quickstart . && \
 popd
 ```
@@ -62,7 +62,7 @@ Finally, deploy the pushed application in your cluster:
 envsubst < k8s/quickstart-app.yaml | kubectl apply -f -
 ```
 
-Once your application is deployed, you can interact with it by hitting either `/single` or `/multi` endpoints on port `8080`. For more information about the application, view the [application readme](uninstrumented-app/quickstart-java/examples/instrumentation-quickstart/README.md).\
+Once your application is deployed, you can interact with it by hitting either `/single` or `/multi` endpoints on port `8080`. For more information about the application, view the [application readme](uninstrumented-app/examples/instrumentation-quickstart/README.md).\
 *Note: You may need to configure port forwarding to interact with this application over localhost.*
 
 ## Instrumenting deployed applications

--- a/recipes/self-managed-otlp-ingest/instrumentation.yaml
+++ b/recipes/self-managed-otlp-ingest/instrumentation.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: opentelemetry.io/v1alpha1
 kind: Instrumentation
 metadata:

--- a/recipes/self-managed-otlp-ingest/instrumentation.yaml
+++ b/recipes/self-managed-otlp-ingest/instrumentation.yaml
@@ -18,10 +18,8 @@ metadata:
   namespace: default
   name: sample-java-auto-instrumentation
 spec:
-  propagators:
-    - tracecontext
-    - baggage
-    - b3
+  exporter:
+    endpoint: http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317
   sampler:
     type: parentbased_traceidratio
     argument: "0.01"
@@ -32,7 +30,3 @@ spec:
         value: grpc
       - name: OTEL_LOGS_EXPORTER
         value: none
-      - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-        value: http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317
-      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-        value: http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317

--- a/recipes/self-managed-otlp-ingest/instrumentation.yaml
+++ b/recipes/self-managed-otlp-ingest/instrumentation.yaml
@@ -18,29 +18,19 @@ metadata:
   namespace: default
   name: sample-java-auto-instrumentation
 spec:
-  exporter:
-    endpoint: http://otel-collector:4317
   propagators:
     - tracecontext
     - baggage
     - b3
   sampler:
-    type: always_on
+    type: parentbased_traceidratio
+    argument: "0.01"
 
   java:
-    resources:
-      limits:
-        memory: 512Mi
-      requests:
-        memory: 512Mi
     env:
-      - name: OTEL_EXPORTER_OTLP_PROTOCOL
-        value: grpc
       - name: OTEL_METRICS_EXPORTER
         value: none
       - name: OTEL_LOGS_EXPORTER
         value: none
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317
-      - name: OTEL_EXPORTER_OTLP_COMPRESSION
-        value: gzip

--- a/recipes/self-managed-otlp-ingest/instrumentation.yaml
+++ b/recipes/self-managed-otlp-ingest/instrumentation.yaml
@@ -1,0 +1,32 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  namespace: default
+  name: sample-java-auto-instrumentation
+spec:
+  exporter:
+    endpoint: http://otel-collector:4317
+  propagators:
+    - tracecontext
+    - baggage
+    - b3
+  sampler:
+    type: always_on
+
+  java:
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        memory: 512Mi
+    env:
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: grpc
+      - name: OTEL_METRICS_EXPORTER
+        value: none
+      - name: OTEL_LOGS_EXPORTER
+        value: none
+      - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+        value: http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317
+      - name: OTEL_EXPORTER_OTLP_COMPRESSION
+        value: gzip

--- a/recipes/self-managed-otlp-ingest/instrumentation.yaml
+++ b/recipes/self-managed-otlp-ingest/instrumentation.yaml
@@ -28,9 +28,11 @@ spec:
 
   java:
     env:
-      - name: OTEL_METRICS_EXPORTER
-        value: none
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: grpc
       - name: OTEL_LOGS_EXPORTER
         value: none
+      - name: OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+        value: http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://opentelemetry-collector.opentelemetry.svc.cluster.local:4317

--- a/recipes/self-managed-otlp-ingest/k8s/kustomization.yaml
+++ b/recipes/self-managed-otlp-ingest/k8s/kustomization.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- quickstart-app.yaml
+- quickstart-traffic.yaml

--- a/recipes/self-managed-otlp-ingest/k8s/quickstart-app.yaml
+++ b/recipes/self-managed-otlp-ingest/k8s/quickstart-app.yaml
@@ -33,7 +33,7 @@ metadata:
   labels:
     app: quickstart-app
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: quickstart-app

--- a/recipes/self-managed-otlp-ingest/k8s/quickstart-app.yaml
+++ b/recipes/self-managed-otlp-ingest/k8s/quickstart-app.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: quickstart-app
+  labels:
+    app: quickstart-app
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+      name: quickstart-app
+  selector:
+    app: quickstart-app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quickstart-app
+  labels:
+    app: quickstart-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: quickstart-app
+  template:
+    metadata:
+      labels:
+        app: quickstart-app
+    spec:
+      containers:
+        - name: quickstart-app
+          image: ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/java-quickstart:latest
+          ports:
+            - containerPort: 8080
+              name: quickstart-app

--- a/recipes/self-managed-otlp-ingest/k8s/quickstart-app.yaml
+++ b/recipes/self-managed-otlp-ingest/k8s/quickstart-app.yaml
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/recipes/self-managed-otlp-ingest/k8s/quickstart-traffic.yaml
+++ b/recipes/self-managed-otlp-ingest/k8s/quickstart-traffic.yaml
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traffic-simulator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: traffic-simulator
+  template:
+    metadata:
+      labels:
+        app: traffic-simulator
+    spec:
+      containers:
+        - name: traffic-simulator
+          image: ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/hey:latest
+          args:
+          - -c=2
+          - -q=1
+          - -z=1h
+          - http://quickstart-app:8080/multi

--- a/recipes/self-managed-otlp-ingest/setup-application.sh
+++ b/recipes/self-managed-otlp-ingest/setup-application.sh
@@ -25,7 +25,7 @@ echo "${REGISTRY_LOCATION:?${UNSET_WARNING}}"
 echo "ENVIRONMENT VARIABLES VERIFIED"
 
 echo "CREATING CLUSTER WITH NAME ${CLUSTER_NAME} in ${CLUSTER_REGION}"
-gcloud beta container --project "${PROJECT_ID}" clusters create-auto "${CLUSTER_NAME}" --region "${CLUSTER_REGION}" --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${CLUSTER_REGION}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=DISABLED
+gcloud beta container --project "${PROJECT_ID}" clusters create-auto "${CLUSTER_NAME}" --region "${CLUSTER_REGION}"
 echo "CLUSTER CREATED SUCCESSFULLY"
 
 echo "PULLING SAMPLE APPLICATION REPOSITORY"

--- a/recipes/self-managed-otlp-ingest/setup-application.sh
+++ b/recipes/self-managed-otlp-ingest/setup-application.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+UNSET_WARNING="Environment variable not set, please set the environment variable"
+
+# Verify necessary environment variables are set
+echo "${PROJECT_ID:?${UNSET_WARNING}}"
+echo "${CLUSTER_NAME:?${UNSET_WARNING}}"
+echo "${CLUSTER_REGION:?${UNSET_WARNING}}"
+echo "${CONTAINER_REGISTRY:?${UNSET_WARNING}}"
+echo "${REGISTRY_LOCATION:?${UNSET_WARNING}}"
+
+echo "ENVIRONMENT VARIABLES VERIFIED"
+
+echo "CREATING CLUSTER WITH NAME ${CLUSTER_NAME} in ${CLUSTER_REGION}"
+gcloud beta container --project "${PROJECT_ID}" clusters create-auto "${CLUSTER_NAME}" --region "${CLUSTER_REGION}" --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${CLUSTER_REGION}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=DISABLED
+echo "CLUSTER CREATED SUCCESSFULLY"
+
+echo "BUILDING SAMPLE APPLICATION IMAGE"
+pushd uninstrumented-app/examples/instrumentation-quickstart && \
+DOCKER_BUILDKIT=1  docker build -f uninstrumented.Dockerfile -t java-quickstart . && \
+popd
+echo "APPLICATION IMAGE BUILT"
+
+echo "CREATING CLOUD ARTIFACT REPOSITORY"
+gcloud artifacts repositories create ${CONTAINER_REGISTRY} --repository-format=docker --location=${REGISTRY_LOCATION} --description="Sample applications to auto-instrument using OTel operator"
+echo "CREATED ${CONTAINER_REGISTRY} in ${REGISTRY_LOCATION}"
+
+echo "PUSHING THE SAMPLE APPLICATION IMAGE TO THE REPOSITORY"
+docker tag java-quickstart:latest ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/java-quickstart:latest
+docker push ${REGISTRY_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${CONTAINER_REGISTRY}/java-quickstart:latest
+echo "APPLICATION IMAGE PUSHED TO ARTIFACT REPOSITORY"
+
+echo "DEPLOYING SAMPLE APPLICATION ON ${CLUSTER_NAME}"
+envsubst < k8s/quickstart-app.yaml | kubectl apply -f -
+echo "SAMPLE APPLICATION DEPLOYED"

--- a/recipes/self-managed-otlp-ingest/setup-application.sh
+++ b/recipes/self-managed-otlp-ingest/setup-application.sh
@@ -28,10 +28,13 @@ echo "CREATING CLUSTER WITH NAME ${CLUSTER_NAME} in ${CLUSTER_REGION}"
 gcloud beta container --project "${PROJECT_ID}" clusters create-auto "${CLUSTER_NAME}" --region "${CLUSTER_REGION}" --release-channel "regular" --tier "standard" --enable-ip-access --no-enable-google-cloud-access --network "projects/${PROJECT_ID}/global/networks/default" --subnetwork "projects/${PROJECT_ID}/regions/${CLUSTER_REGION}/subnetworks/default" --cluster-ipv4-cidr "/17" --binauthz-evaluation-mode=DISABLED
 echo "CLUSTER CREATED SUCCESSFULLY"
 
+echo "PULLING SAMPLE APPLICATION REPOSITORY"
 echo "BUILDING SAMPLE APPLICATION IMAGE"
-pushd uninstrumented-app/examples/instrumentation-quickstart && \
+git clone https://github.com/GoogleCloudPlatform/opentelemetry-operations-java.git
+pushd opentelemetry-operations-java/examples/instrumentation-quickstart && \
 DOCKER_BUILDKIT=1  docker build -f uninstrumented.Dockerfile -t java-quickstart . && \
-popd
+popd && \
+rm -rf opentelemetry-operations-java
 echo "APPLICATION IMAGE BUILT"
 
 echo "CREATING CLOUD ARTIFACT REPOSITORY"

--- a/recipes/self-managed-otlp-ingest/traffic/hey.Dockerfile
+++ b/recipes/self-managed-otlp-ingest/traffic/hey.Dockerfile
@@ -15,6 +15,8 @@
 FROM golang:1.21-alpine3.19 AS build
 
 RUN apk add --no-cache wget
+# The link for the binary is specified in library's README
+# https://github.com/rakyll/hey/blob/master/README.md
 RUN wget -O /hey https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64
 RUN chmod +x /hey
 

--- a/recipes/self-managed-otlp-ingest/traffic/hey.Dockerfile
+++ b/recipes/self-managed-otlp-ingest/traffic/hey.Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.21-alpine3.19 AS build
+
+RUN apk add --no-cache wget
+RUN wget -O /hey https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64
+RUN chmod +x /hey
+
+FROM scratch
+COPY --from=build /hey /hey
+
+ENTRYPOINT ["/hey"]


### PR DESCRIPTION
This PR adds a recipe to showcase the use of OpenTelemetry Operator with self managed OTLP collector configured to export to Google Cloud.

The operator adds and manages the instrumentation for the sample Java app (instrumentation-quickstart app).

The instrumentation is configured to export traces to the self-managed collector.